### PR TITLE
feat: Add toast notifications to 'Save tags' button in image_detail.html

### DIFF
--- a/templates/image_detail.html
+++ b/templates/image_detail.html
@@ -29,25 +29,64 @@
     </div>
 
     <script src="/static/js/autocomplete.js"></script>
+	<script src="/static/js/notifications.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
 
             // --- 1. DOM ELEMENT REFERENCES ---
             const tagInput = document.getElementById('tags');
             const suggestionsBox = document.querySelector('.suggestions');
+            const editForm = document.querySelector('.edit-form');
 
-            // --- 2. INITIALIZATION ---
+
+            // --- 2. EVENT HANDLERS ---
 
             /**
-             * Sets up the page by initializing the tag autocomplete component.
+             * Handles the form submission for editing tags.
+             * Submits the data asynchronously and shows a toast notification on completion.
+             * @param {Event} event - The form submission event.
+             */
+            async function handleFormSubmit(event) {
+                event.preventDefault(); // Prevent default page reload
+
+                const formData = new FormData(editForm);
+                const url = editForm.action;
+
+                try {
+                    const response = await fetch(url, {
+                        method: 'POST',
+                        body: new URLSearchParams(formData)
+                    });
+
+                    if (response.ok) {
+                        showToast('Tags saved successfully!', 'success');
+                    } else {
+                        console.error('Failed to save tags:', response.status, response.statusText);
+                        showToast(`Error: Could not save tags (server error).`, 'error');
+                    }
+                } catch (error) {
+                    console.error('Form submission failed:', error);
+                    showToast('Error: Could not save tags (network error).', 'error');
+                }
+            }
+
+
+            // --- 3. INITIALIZATION ---
+
+            /**
+             * Sets up the page by initializing the tag autocomplete and form handler.
              */
             function initialize() {
                 // Set up autocomplete for the tag input field.
-                // Saved searches are intentionally disabled on this page.
                 setupTagAutocomplete(tagInput, suggestionsBox);
+
+                // Attach the async submit handler to the form.
+                if (editForm) {
+                    editForm.addEventListener('submit', handleFormSubmit);
+                }
             }
 
-            // --- 3. START THE APPLICATION ---
+            // --- 4. START THE APPLICATION ---
             initialize();
         });
     </script>


### PR DESCRIPTION
Adds asynchronous form submission to the image detail page. When you click 'Save Tags', the form data is now submitted via the Fetch API instead of a full page reload.

A toast notification is displayed to you to indicate the result of the operation:
- A success message is shown if the tags are saved correctly.
- An error message is shown if there is a network issue or a server error.

This improves your experience by providing immediate, non-disruptive feedback without navigating away from the page.

Closes #8 