### PR TITLE
feat: introducing tag categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A simple, self-hosted image gallery (booru) with a focus on powerful tagging and
 ## Features
 
 *   **Duplicate-Aware Uploads:** Upload multiple images at once. The system calculates a SHA256 hash for each file and automatically ignores any duplicates, ensuring a clean media library.
-*   **Flexible Tagging:** The core of the application is built on a many-to-many relationship between images and tags. Tags can be managed individually or through powerful batch actions.
+*   **Categorized Tagging:** Go beyond simple tags with a structured category system (`general`, `artist`, `character`, `copyright`, `metadata`). Tags are color-coded for instant recognition, and you can search with prefixes (e.g., `artist:name`) for more precise filtering.
 *   **Comprehensive Search:** A search bar with a dedicated query syntax supports finding images by a combination of tags. Includes support for:
     *   `AND` logic (`tag1, tag2`)
     *   `OR` logic (`(tag1 | tag2)`)
@@ -16,13 +16,10 @@ A simple, self-hosted image gallery (booru) with a focus on powerful tagging and
     *   `Wildcard` matching (`art*`)
     *   A special `untagged` keyword.
 *   **Saved Searches:** Automatically remembers your recent search queries for quick recall. "Pin" your most-used or complex searches for permanent, prioritized access. A dedicated management page allows you to view, pin, and delete all saved queries.
-*   **Gallery & Viewer:** A paginated thumbnail grid for browsing the collection. Thumbnail sizes are configurable (S/M/L) and saved in the browser. Includes a full-screen lightbox viewer with keyboard navigation for cycling through images.
+*   **Gallery & Viewer:** A paginated, masonry-style thumbnail grid for browsing the collection. Includes a full-screen lightbox viewer and an on-demand tag tooltip system (toggle with `T`).
 *   **Batch Actions:** A dedicated page for modifying large sets of images at once. Selections are persistent across pages, allowing you to add, remove, or replace tags, or to permanently delete images in bulk.
 *   **Persistent Undo:** Reverts the last batch *tagging* operation (add, remove, or replace). The undo state is saved to disk, so it persists even after restarting the application.
-*   **Tag Management:** A dedicated page for database-level tag maintenance, essential for keeping a tag library clean and organized.
-    *   Filter tags by name and view unused (orphan) tags.
-    *   Sort tags alphabetically or by image count.
-    *   Rename, merge, and force-delete tags.
+*   **Tag Management:** A dedicated page for database-level tag maintenance. Rename, merge, delete, or change the category of any tag.
 
 ## Getting Started
 
@@ -71,11 +68,11 @@ Follow these steps to get `local-booru` running on your local machine.
 
 ## How to Use
 
-1.  **Upload:** Go to the "Upload" page to add your first images.
-2.  **Browse:** Navigate to the "Gallery" to see your collection.
-3.  **Search:** Use the search bar at the top of the gallery to filter your images. Click an empty search bar to see your saved and recent queries. Click the "Help" link for a full guide on the search syntax.
-4.  **Edit or Delete:** Click any image to open the lightbox viewer. From there, click "Edit Tags" to go to the image's dedicated page where you can update its tags, or "Delete" to remove it permanently from your collection.
-5.  **Organize:** Use the "Batch Actions" and "Tag Manager" pages for larger-scale organization.
+1.  **Upload:** Go to the "Upload" page to add your first images. You can add categorized tags directly on upload (e.g., `artist:someartist, character:somechar, tag1`).
+2.  **Browse:** Navigate to the "Gallery" to see your collection. Press `T` to toggle the tag tooltips on and off.
+3.  **Search:** Use the search bar to filter images. You can now search by category (e.g., `character:reimu_hakurei`).
+4.  **Edit or Delete:** Click any image to open the lightbox viewer. From there, click "Edit Tags" to go to the image's dedicated page, or "Delete" to remove it.
+5.  **Organize:** Use the "Batch Actions" and "Tag Manager" pages for larger-scale organization, including changing tag categories.
 6.  **Manage Searches:** Visit the "Saved Searches" page to organize your pinned and recent search queries.
 
 ## Maintenance

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ class ChangeCategoryRequest(BaseModel):
 app = FastAPI(
     title="local-booru",
     description="A self-hosted image gallery with advanced tagging.",
-    version="1.5.0",
+    version="1.6.0",
 )
 
 # --- Constants ---

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -290,17 +290,23 @@ form.search-form button:hover { background-color: var(--color-accent-hover); }
 
 .gallery { display: flex; flex-wrap: wrap; gap: 1rem; justify-content: center; }
 .thumb {
-    width: var(--thumb-width); box-sizing: border-box;
-    text-align: center; position: relative; border-radius: var(--border-radius);
+    width: var(--thumb-width);
+    box-sizing: border-box;
+    text-align: center;
+    position: relative;
+    border-radius: var(--border-radius);
 }
 .thumb img {
-    max-width: 100%; height: auto; cursor: pointer;
-    display: block; border-radius: var(--border-radius);
+    max-width: 100%;
+    height: auto;
+    cursor: pointer;
+    display: block;
+    border-radius: var(--border-radius);
 }
 
-/* New: Styles for the hover tooltip */
-.thumb-tooltip {
-    position: fixed; /* Position relative to the viewport for accurate placement */
+/* Reverted: Styles for the dynamic hover tooltip */
+#tag-tooltip {
+    position: fixed;
     background-color: rgba(18, 18, 18, 0.95);
     padding: 0.5rem;
     border-radius: var(--border-radius);
@@ -310,15 +316,16 @@ form.search-form button:hover { background-color: var(--color-accent-hover); }
     max-width: 300px;
     text-align: left;
     
-    /* Animation and visibility */
     opacity: 0;
     visibility: hidden;
     transition: opacity 0.2s ease-in-out, visibility 0.2s ease-in-out;
-    pointer-events: auto; /* Allow interaction with the tooltip and its content */
+    pointer-events: auto;
 }
-.thumb-tooltip.visible { opacity: 1; visibility: visible; }
-/* New: Special class for dimension calculation without visual flicker */
-.thumb-tooltip.visible-calculating {
+#tag-tooltip.visible {
+    opacity: 1;
+    visibility: visible;
+}
+#tag-tooltip.visible-calculating {
     visibility: hidden !important;
     display: block !important;
     opacity: 0 !important;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -288,13 +288,22 @@ form.search-form button {
 }
 form.search-form button:hover { background-color: var(--color-accent-hover); }
 
-.gallery { display: flex; flex-wrap: wrap; gap: 1rem; justify-content: center; }
+.gallery {
+    column-width: var(--thumb-width);
+    column-count: auto;
+    column-gap: 1rem;
+}
 .thumb {
-    width: var(--thumb-width);
+    width: 100%;
+    margin-bottom: 1rem;
+    break-inside: avoid;
+    display: inline-block;
     box-sizing: border-box;
     text-align: center;
     position: relative;
     border-radius: var(--border-radius);
+    /* Corrected: This is a standard fix for rendering/event bugs in column layouts */
+    transform: translateZ(0);
 }
 .thumb img {
     max-width: 100%;
@@ -304,7 +313,6 @@ form.search-form button:hover { background-color: var(--color-accent-hover); }
     border-radius: var(--border-radius);
 }
 
-/* Reverted: Styles for the dynamic hover tooltip */
 #tag-tooltip {
     position: fixed;
     background-color: rgba(18, 18, 18, 0.95);
@@ -388,9 +396,32 @@ form.search-form button:hover { background-color: var(--color-accent-hover); }
 
 /* --- 3.5 Batch Actions Page --- */
 #selection-controls, .page-actions { text-align: center; margin: 1rem 0; }
-.batch-gallery .thumb { border: 2px solid var(--color-border); user-select: none; cursor: pointer; overflow: visible; }
+.batch-gallery {
+    /* New: Apply masonry layout to batch actions page as well */
+    column-width: var(--thumb-width);
+    column-count: auto;
+    column-gap: 1rem;
+}
+.batch-gallery .thumb {
+    /* New: Styling for items within the masonry layout */
+    width: 100%;
+    margin-bottom: 1rem;
+    break-inside: avoid;
+    display: inline-block;
+
+    /* Keep existing styles */
+    border: 2px solid var(--color-border);
+    user-select: none;
+    cursor: pointer;
+    overflow: visible;
+    transform: translateZ(0); /* New: Fix for column layout event bugs */
+}
 .batch-gallery .thumb.selected { border-color: var(--color-accent); }
 .batch-gallery .thumb img { pointer-events: none; }
+/* New: Center the tag pills in batch mode */
+.batch-gallery .tag-pills-container {
+    justify-content: center;
+}
 #selection-controls button {
     padding: 0.5rem 1rem; margin: 0 0.2rem; cursor: pointer;
     border: 1px solid var(--color-border); background-color: var(--color-bg-tertiary);

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -6,7 +6,7 @@
       - Body & Typography (body, h1, a, code, etc.)
 
    2. Reusable Components
-      - 2.1 Autocomplete
+      - 2.1 Autocomplete & Tag Pills
       - 2.2 Generic Action Button
       - 2.3 Toast Notifications
 
@@ -42,6 +42,13 @@
     --color-info: #2196F3;
     --color-warning: #ff9800;
     --color-neutral: #6c757d;
+
+    /* Tag Category Colors */
+    --tag-color-general: #4a90e2;
+    --tag-color-artist: #28a745;
+    --tag-color-character: #9c27b0;
+    --tag-color-copyright: #ff9800;
+    --tag-color-metadata: #6c757d;
 
     /* Layout */
     --border-radius: 4px;
@@ -80,7 +87,7 @@ code {
    2. Reusable Components
    ========================================================================== */
 
-/* --- 2.1 Autocomplete --- */
+/* --- 2.1 Autocomplete & Tag Pills --- */
 .autocomplete-container {
     position: relative;
     width: 100%;
@@ -105,7 +112,7 @@ code {
 }
 
 .suggestions > div {
-    padding: 0.8rem 1rem;
+    padding: 0.5rem 0.8rem;
     cursor: pointer;
     color: var(--color-text-primary);
     line-height: 1.4;
@@ -136,71 +143,60 @@ code {
 }
 
 .suggestion-controls button {
-    background: none;
-    border: none;
-    color: var(--color-text-secondary);
-    font-size: 1.1em;
-    padding: 0;
-    cursor: pointer;
-    opacity: 0.6;
-    transition: opacity 0.2s;
-    appearance: none;
+    background: none; border: none; color: var(--color-text-secondary);
+    font-size: 1.1em; padding: 0; cursor: pointer; opacity: 0.6;
+    transition: opacity 0.2s; appearance: none;
 }
-.suggestion-controls button:hover {
-    opacity: 1;
-    color: var(--color-accent);
-}
+.suggestion-controls button:hover { opacity: 1; color: var(--color-accent); }
 
 .suggestions-header {
-    padding: 0.6rem 1rem;
-    font-size: 0.8em;
-    font-weight: bold;
-    color: var(--color-text-secondary);
-    background-color: var(--color-bg-primary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    border-bottom: 1px solid var(--color-border);
-    cursor: default;
+    padding: 0.6rem 1rem; font-size: 0.8em; font-weight: bold;
+    color: var(--color-text-secondary); background-color: var(--color-bg-primary);
+    text-transform: uppercase; letter-spacing: 0.5px;
+    border-bottom: 1px solid var(--color-border); cursor: default;
 }
-.suggestions-header:hover {
-    background-color: var(--color-bg-primary);
+.suggestions-header:hover { background-color: var(--color-bg-primary); }
+
+.tag-pill {
+    display: inline-block; padding: 0.2em 0.6em; margin: 0.1em;
+    border-radius: var(--border-radius); font-size: 0.85em; font-weight: 500;
+    line-height: 1.4; color: white; text-decoration: none;
+}
+
+a.tag-pill:hover { filter: brightness(1.2); }
+
+.tag-general { background-color: var(--tag-color-general); }
+.tag-artist { background-color: var(--tag-color-artist); }
+.tag-character { background-color: var(--tag-color-character); }
+.tag-copyright { background-color: var(--tag-color-copyright); }
+.tag-metadata { background-color: var(--tag-color-metadata); }
+
+.suggestion-tag-pill {
+    display: inline-block; padding: 0.2em 0.6em;
+    border-radius: var(--border-radius); color: white; font-weight: 500;
 }
 
 
 /* --- 2.2 Generic Action Button --- */
 .action-button {
-    display: inline-block;
-    padding: 0.5rem 1rem;
-    font-size: 0.8rem;
-    cursor: pointer;
-    border: 1px solid var(--color-border);
-    background-color: var(--color-bg-tertiary);
-    text-align: center;
-    text-decoration: none;
-    color: var(--color-text-primary);
+    display: inline-block; padding: 0.5rem 1rem; font-size: 0.8rem;
+    cursor: pointer; border: 1px solid var(--color-border);
+    background-color: var(--color-bg-tertiary); text-align: center;
+    text-decoration: none; color: var(--color-text-primary);
     border-radius: var(--border-radius);
 }
 
 
 /* --- 2.3 Toast Notifications --- */
 #toast-container {
-    position: fixed;
-    bottom: 20px;
-    right: 20px;
-    z-index: 1000;
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
+    position: fixed; bottom: 20px; right: 20px; z-index: 1000;
+    display: flex; flex-direction: column; gap: 10px;
 }
 
 .toast {
-    padding: 15px 20px;
-    border-radius: var(--border-radius);
-    color: white;
-    font-weight: bold;
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
-    opacity: 1;
-    transition: opacity 0.5s ease-in-out, transform 0.3s ease-in-out;
+    padding: 15px 20px; border-radius: var(--border-radius); color: white;
+    font-weight: bold; box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+    opacity: 1; transition: opacity 0.5s ease-in-out, transform 0.3s ease-in-out;
 }
 .toast-success { background-color: #4CAF50; }
 .toast-error   { background-color: var(--color-danger); }
@@ -214,249 +210,135 @@ code {
 
 /* --- 3.1 Index Page --- */
 .index-page-container { max-width: 600px; margin: auto; }
-
-form.search-form-index {
-    margin: 0.7rem auto;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
+form.search-form-index { margin: 0.7rem auto; display: flex; justify-content: center; align-items: center; }
 form.search-form-index input[type="text"] {
-    width: 100%;
-    padding: 0.7rem;
-    font-size: 1.1rem;
-    box-sizing: border-box;
-    border: 1px solid var(--color-border);
-    border-right: none;
-    outline: none;
-    background-color: var(--color-bg-tertiary);
-    color: var(--color-text-primary);
+    width: 100%; padding: 0.7rem; font-size: 1.1rem; box-sizing: border-box;
+    border: 1px solid var(--color-border); border-right: none; outline: none;
+    background-color: var(--color-bg-tertiary); color: var(--color-text-primary);
     border-radius: var(--border-radius) 0 0 var(--border-radius);
 }
-
 form.search-form-index button {
-    padding: 0.7rem 1.2rem;
-    font-size: 1.1rem;
-    cursor: pointer;
-    border: 1px solid var(--color-accent);
-    background-color: var(--color-accent);
-    color: white;
-    outline: none;
-    transition: background-color 0.2s;
+    padding: 0.7rem 1.2rem; font-size: 1.1rem; cursor: pointer; border: 1px solid var(--color-accent);
+    background-color: var(--color-accent); color: white; outline: none; transition: background-color 0.2s;
     border-radius: 0 var(--border-radius) var(--border-radius) 0;
 }
-form.search-form-index button:hover {
-    background-color: var(--color-accent-hover);
-}
-
+form.search-form-index button:hover { background-color: var(--color-accent-hover); }
 .image-counter { display: flex; justify-content: center; align-items: center; gap: 0.25rem; margin-top: 2rem; }
 .image-counter img { height: 136px; }
 
 
 /* --- 3.2 Upload Page --- */
 .upload-form-container { max-width: 600px; margin: auto; }
-
 #drop-zone {
-    border: 3px dashed var(--color-border);
-    border-radius: var(--border-radius);
-    padding: 2rem;
-    text-align: center;
-    transition: border-color 0.3s, background-color 0.3s;
-    margin-bottom: 1rem;
-    background-color: var(--color-bg-secondary);
+    border: 3px dashed var(--color-border); border-radius: var(--border-radius);
+    padding: 2rem; text-align: center; transition: border-color 0.3s, background-color 0.3s;
+    margin-bottom: 1rem; background-color: var(--color-bg-secondary);
 }
-
-#drop-zone.drag-over {
-    border-color: var(--color-accent);
-    background-color: var(--color-bg-tertiary);
-}
-
-#drop-zone p {
-    margin: 0;
-    color: var(--color-text-secondary);
-}
-
-#drop-zone svg {
-    color: var(--color-text-secondary);
-    margin-bottom: 1rem;
-}
-
-.drop-zone-actions {
-    margin-top: 1rem;
-    color: var(--color-text-secondary);
-}
-.drop-zone-actions a {
-    color: var(--color-accent);
-    text-decoration: underline;
-    cursor: pointer;
-    font-weight: bold;
-}
-.drop-zone-actions span {
-    margin: 0 0.5rem;
-}
-
-
+#drop-zone.drag-over { border-color: var(--color-accent); background-color: var(--color-bg-tertiary); }
+#drop-zone p { margin: 0; color: var(--color-text-secondary); }
+#drop-zone svg { color: var(--color-text-secondary); margin-bottom: 1rem; }
+.drop-zone-actions { margin-top: 1rem; color: var(--color-text-secondary); }
+.drop-zone-actions a { color: var(--color-accent); text-decoration: underline; cursor: pointer; font-weight: bold; }
+.drop-zone-actions span { margin: 0 0.5rem; }
 .upload-form input[type="text"] {
-    width: 100%;
-    padding: 0.7rem;
-    font-size: 1.1rem;
-    box-sizing: border-box;
-    border: 1px solid var(--color-border);
-    border-radius: var(--border-radius);
-    outline: none;
-    background-color: var(--color-bg-tertiary);
-    color: var(--color-text-primary);
+    width: 100%; padding: 0.7rem; font-size: 1.1rem; box-sizing: border-box;
+    border: 1px solid var(--color-border); border-radius: var(--border-radius);
+    outline: none; background-color: var(--color-bg-tertiary); color: var(--color-text-primary);
 }
-
 .upload-form .autocomplete-container { width: 100%; margin-bottom: 1rem; }
 .upload-form .suggestions { border-top: 1px solid var(--color-border); }
-
-.upload-form #upload-button {
-    background-color: var(--color-accent);
-    color: white;
-    border: none;
-    border-radius: var(--border-radius);
-    width: 100%;
-}
-
-.upload-form #upload-button:disabled {
-    background-color: var(--color-neutral);
-    cursor: not-allowed;
-}
-
+.upload-form #upload-button { background-color: var(--color-accent); color: white; border: none; border-radius: var(--border-radius); width: 100%; }
+.upload-form #upload-button:disabled { background-color: var(--color-neutral); cursor: not-allowed; }
 #upload-status {margin: 0.5rem 0;}
-
 #queue-controls {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 1rem;
-    padding: 0.5rem;
-    background-color: var(--color-bg-secondary);
+    display: flex; justify-content: space-between; align-items: center;
+    margin-bottom: 1rem; padding: 0.5rem; background-color: var(--color-bg-secondary);
     border-radius: var(--border-radius);
 }
-#queue-controls #clear-queue-btn {
-    background-color: var(--color-neutral);
-    font-size: 0.7rem;
-    padding: 0.4rem 0.8rem;
-}
-
+#queue-controls #clear-queue-btn { background-color: var(--color-neutral); font-size: 0.7rem; padding: 0.4rem 0.8rem; }
 #preview-container {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
-    margin-bottom: 1rem;
-    justify-content: flex-start;
-    background-color: var(--color-bg-secondary);
-    border-radius: var(--border-radius);
-    padding: 10px;
-    min-height: 50px;
-    max-height: 250px;
-    overflow-y: auto;
+    display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 1rem;
+    justify-content: flex-start; background-color: var(--color-bg-secondary);
+    border-radius: var(--border-radius); padding: 10px; min-height: 50px;
+    max-height: 250px; overflow-y: auto;
 }
-.preview-thumb-wrapper {
-    position: relative;
-}
-.preview-thumb {
-    width: 105px;
-    height: 105px;
-    object-fit: cover;
-    border: 1px solid var(--color-border);
-    border-radius: var(--border-radius);
-    display: block;
-}
+.preview-thumb-wrapper { position: relative; }
+.preview-thumb { width: 105px; height: 105px; object-fit: cover; border: 1px solid var(--color-border); border-radius: var(--border-radius); display: block; }
 .preview-remove-btn {
-    position: absolute;
-    top: -5px;
-    right: -5px;
-    width: 20px;
-    height: 20px;
-    background-color: var(--color-danger);
-    color: white;
-    border: 1px solid var(--color-bg-primary);
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-weight: bold;
-    cursor: pointer;
-    opacity: 0.8;
-    transition: opacity 0.2s;
+    position: absolute; top: -5px; right: -5px; width: 20px; height: 20px;
+    background-color: var(--color-danger); color: white; border: 1px solid var(--color-bg-primary);
+    border-radius: 50%; display: flex; align-items: center; justify-content: center;
+    font-weight: bold; cursor: pointer; opacity: 0.8; transition: opacity 0.2s;
 }
-.preview-remove-btn:hover {
-    opacity: 1;
-}
+.preview-remove-btn:hover { opacity: 1; }
 
 
 /* --- 3.3 Gallery & Lightbox --- */
-form.search-form {
-    margin: 0.7rem auto;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
+form.search-form { margin: 0.7rem auto; display: flex; justify-content: center; align-items: center; }
 form.search-form input[type="text"] {
-    width: 100%;
-    padding: 0.7rem;
-    font-size: 1.1rem;
-    box-sizing: border-box;
-    border: 1px solid var(--color-border);
-    border-right: none;
-    outline: none;
-    background-color: var(--color-bg-tertiary);
-    color: var(--color-text-primary);
+    width: 100%; padding: 0.7rem; font-size: 1.1rem; box-sizing: border-box;
+    border: 1px solid var(--color-border); border-right: none; outline: none;
+    background-color: var(--color-bg-tertiary); color: var(--color-text-primary);
     border-radius: var(--border-radius) 0 0 var(--border-radius);
 }
-
 form.search-form button {
-    padding: 0.7rem 1.2rem;
-    font-size: 1.1rem;
-    cursor: pointer;
-    border: 1px solid var(--color-accent);
-    background-color: var(--color-accent);
-    color: white;
-    outline: none;
-    transition: background-color 0.2s;
+    padding: 0.7rem 1.2rem; font-size: 1.1rem; cursor: pointer; border: 1px solid var(--color-accent);
+    background-color: var(--color-accent); color: white; outline: none; transition: background-color 0.2s;
     border-radius: 0 var(--border-radius) var(--border-radius) 0;
 }
-form.search-form button:hover {
-    background-color: var(--color-accent-hover);
-}
+form.search-form button:hover { background-color: var(--color-accent-hover); }
 
 .gallery { display: flex; flex-wrap: wrap; gap: 1rem; justify-content: center; }
-.thumb { width: var(--thumb-width); box-sizing: border-box; text-align: center; position: relative; overflow: hidden; border-radius: var(--border-radius); }
-.thumb img { max-width: 100%; height: auto; cursor: pointer; display: block; }
-
-.tags {
-    position: absolute; bottom: 0; left: 0; right: 0;
-    background-color: rgba(0, 0, 0, 0.7);
-    color: white; padding: 0.5rem; font-size: 0.75rem;
-    word-wrap: break-word; opacity: 0;
-    transition: opacity 0.2s ease-in-out;
+.thumb {
+    width: var(--thumb-width); box-sizing: border-box;
+    text-align: center; position: relative; border-radius: var(--border-radius);
 }
-.thumb:hover .tags { opacity: 1; }
+.thumb img {
+    max-width: 100%; height: auto; cursor: pointer;
+    display: block; border-radius: var(--border-radius);
+}
 
+/* New: Styles for the hover tooltip */
+.thumb-tooltip {
+    position: fixed; /* Position relative to the viewport for accurate placement */
+    background-color: rgba(18, 18, 18, 0.95);
+    padding: 0.5rem;
+    border-radius: var(--border-radius);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
+    z-index: 50;
+    width: max-content;
+    max-width: 300px;
+    text-align: left;
+    
+    /* Animation and visibility */
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s ease-in-out, visibility 0.2s ease-in-out;
+    pointer-events: auto; /* Allow interaction with the tooltip and its content */
+}
+.thumb-tooltip.visible { opacity: 1; visibility: visible; }
+/* New: Special class for dimension calculation without visual flicker */
+.thumb-tooltip.visible-calculating {
+    visibility: hidden !important;
+    display: block !important;
+    opacity: 0 !important;
+}
+
+.tag-pills-container { display: flex; flex-wrap: wrap; gap: 4px; padding: 0.2rem; }
 .search-actions { text-align: center; margin-bottom: 1rem; }
 .search-actions .action-button:nth-child(2) { margin-left: 1rem; }
-
 #thumbnail-controls { text-align: center; margin-bottom: 1rem; }
 #thumbnail-controls button {
     padding: 0.4rem 1rem; cursor: pointer; border: 1px solid var(--color-border);
     background-color: var(--color-bg-tertiary); color: var(--color-text-primary);
     border-radius: var(--border-radius);
 }
-#thumbnail-controls button.active {
-    background-color: var(--color-accent);
-    color: white; border-color: var(--color-accent);
-}
+#thumbnail-controls button.active { background-color: var(--color-accent); color: white; border-color: var(--color-accent); }
 
 #lightbox-modal {
-    position: fixed; top: 0; left: 0;
-    width: 100%; height: 100%;
-    background-color: rgba(0, 0, 0, 0.9);
-    display: none; justify-content: center; align-items: center; z-index: 100;
+    position: fixed; top: 0; left: 0; width: 100%; height: 100%;
+    background-color: rgba(0, 0, 0, 0.9); display: none;
+    justify-content: center; align-items: center; z-index: 100;
 }
 #lightbox-content { position: relative; max-width: 90%; max-height: 90%; display: flex; flex-direction: column; align-items: center; }
 #lightbox-image { max-width: 100%; max-height: 80vh; object-fit: contain; border-radius: var(--border-radius); }
@@ -465,7 +347,8 @@ form.search-form button:hover {
 .lightbox-nav button { background: rgba(0, 0, 0, 0.5); color: #fff; border: none; padding: 15px; cursor: pointer; font-size: 24px; border-radius: 5px; }
 .lightbox-info { color: #fff; text-align: center; background: rgba(0, 0, 0, 0.6); max-width: 80%; padding: 1rem; border-radius: 5px; margin-top: 1rem; }
 .lightbox-info .action-button { background-color: var(--color-accent); border-color: var(--color-accent); margin-top: 1rem; }
-.lightbox-info h4, .lightbox-info p { margin: 0; padding-bottom: 0.5rem; }
+.lightbox-info h4 { margin: 0; padding-bottom: 0.5rem; }
+.lightbox-info .tag-pills-container { justify-content: center; }
 
 #pagination { text-align: center; }
 #pagination button {
@@ -474,23 +357,9 @@ form.search-form button:hover {
     color: var(--color-text-primary); border-radius: var(--border-radius);
 }
 #pagination button:disabled { cursor: not-allowed; opacity: 0.5; }
-
-.lightbox-actions {
-    display: flex;
-    justify-content: center;
-    gap: 1rem;
-}
-
-.action-button.danger {
-    background-color: var(--color-danger);
-    color: white;
-    border-color: var(--color-danger);
-}
-
-.action-button.danger:hover {
-    background-color: #c53030;
-    border-color: #c53030;
-}
+.lightbox-actions { display: flex; justify-content: center; gap: 1rem; }
+.action-button.danger { background-color: var(--color-danger); color: white; border-color: var(--color-danger); }
+.action-button.danger:hover { background-color: #c53030; border-color: #c53030; }
 
 
 /* --- 3.4 Image Detail Page --- */
@@ -500,18 +369,9 @@ form.search-form button:hover {
 .detail-page-container .edit-form { width: 100%; max-width: 700px; text-align: center; }
 .detail-page-container .edit-form label { display: block; margin-bottom: 0.5rem; font-size: 1.2rem; font-weight: bold; }
 .detail-page-container .edit-form textarea {
-    width: 100%;
-    min-height: 0;
-    padding: 0.7rem;
-    font-size: 1.1rem;
-    font-family: sans-serif;
-    box-sizing: border-box;
-    border: 1px solid var(--color-border);
-    background-color: var(--color-bg-tertiary);
-    color: var(--color-text-primary);
-    margin-bottom: 0.5rem;
-    resize: vertical;
-    border-radius: var(--border-radius);
+    width: 100%; min-height: 0; padding: 0.7rem; font-size: 1.1rem; font-family: sans-serif;
+    box-sizing: border-box; border: 1px solid var(--color-border); background-color: var(--color-bg-tertiary);
+    color: var(--color-text-primary); margin-bottom: 0.5rem; resize: vertical; border-radius: var(--border-radius);
 }
 .detail-page-container .form-actions { display: inline-block; padding-bottom: 1.0rem; }
 .detail-page-container .form-actions .action-button { font-size: 0.9rem; padding: 0.8rem 1.5rem; }
@@ -521,22 +381,21 @@ form.search-form button:hover {
 
 /* --- 3.5 Batch Actions Page --- */
 #selection-controls, .page-actions { text-align: center; margin: 1rem 0; }
-.batch-gallery .thumb { border: 2px solid var(--color-border); padding: 0.3rem; user-select: none; cursor: pointer; }
+.batch-gallery .thumb { border: 2px solid var(--color-border); user-select: none; cursor: pointer; overflow: visible; }
 .batch-gallery .thumb.selected { border-color: var(--color-accent); }
 .batch-gallery .thumb img { pointer-events: none; }
-#selection-controls button { padding: 0.5rem 1rem; margin: 0 0.2rem; cursor: pointer; border: 1px solid var(--color-border); background-color: var(--color-bg-tertiary); color: var(--color-text-primary); border-radius: var(--border-radius); }
+#selection-controls button {
+    padding: 0.5rem 1rem; margin: 0 0.2rem; cursor: pointer;
+    border: 1px solid var(--color-border); background-color: var(--color-bg-tertiary);
+    color: var(--color-text-primary); border-radius: var(--border-radius);
+}
 #selection-controls button:disabled { cursor: not-allowed; opacity: 0.5; }
 #batch-edit-form { max-width: 600px; margin: 1rem auto; border: 1px solid var(--color-border); padding: 1rem; background: var(--color-bg-secondary); border-radius: var(--border-radius); }
 #batch-edit-form label { display: block; margin: 0.5rem 0; font-weight: bold; }
 #batch-edit-form input[type="text"] {
-    width: 100%;
-    padding: 0.4rem;
-    box-sizing: border-box;
-    margin-bottom: 0.5rem;
-    font-size: 1rem;
-    background-color: var(--color-bg-tertiary);
-    color: var(--color-text-primary);
-    border: 1px solid var(--color-border);
+    width: 100%; padding: 0.4rem; box-sizing: border-box; margin-bottom: 0.5rem;
+    font-size: 1rem; background-color: var(--color-bg-tertiary);
+    color: var(--color-text-primary); border: 1px solid var(--color-border);
     border-radius: var(--border-radius);
 }
 #batch-edit-form button { padding: 0.5rem 1rem; font-size: 1rem; border-radius: var(--border-radius); }
@@ -548,19 +407,19 @@ form.search-form button:hover {
 /* --- 3.6 Tag Manager Page --- */
 .tag-manager-container { max-width: 800px; margin: auto; text-align: left; }
 .tag-manager-container a.back.action-button { margin-bottom: 2rem; display: inline-block; }
-.tag-manager-controls { display: flex; flex-wrap: wrap; gap: 1rem; justify-content: space-between; align-items: center; padding: 1rem; margin-bottom: 1.5rem; background-color: var(--color-bg-secondary); border: 1px solid var(--color-border); border-radius: var(--border-radius); }
+.tag-manager-controls {
+    display: flex; flex-wrap: wrap; gap: 1rem; justify-content: space-between;
+    align-items: center; padding: 1rem; margin-bottom: 1.5rem;
+    background-color: var(--color-bg-secondary); border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+}
 .tag-manager-controls .autocomplete-container { flex-grow: 1; min-width: 250px; }
 .tag-manager-controls .sort-buttons, .tag-manager-controls .filter-options { display: flex; align-items: center; gap: 0.5rem; color: var(--color-text-secondary); }
 .tag-manager-controls .action-button.active { background-color: var(--color-accent); color: white; border-color: var(--color-accent); }
 .tag-manager-container input[type="text"] {
-    padding: 0.4rem;
-    font-size: 1rem;
-    box-sizing: border-box;
-    width: 100%;
-    outline: none;
-    background-color: var(--color-bg-tertiary);
-    color: var(--color-text-primary);
-    border: 1px solid var(--color-border);
+    padding: 0.4rem; font-size: 1rem; box-sizing: border-box; width: 100%;
+    outline: none; background-color: var(--color-bg-tertiary);
+    color: var(--color-text-primary); border: 1px solid var(--color-border);
     border-radius: var(--border-radius);
 }
 .tag-list { list-style-type: none; padding: 0; min-height: 50px; }
@@ -575,12 +434,21 @@ form.search-form button:hover {
 .merge-btn { background-color: var(--color-success); color: white; border-color: var(--color-success); }
 .force-delete-btn { background-color: var(--color-danger); color: white; border-color: var(--color-danger); }
 .cancel-btn { background-color: var(--color-neutral); color: white; border-color: var(--color-neutral); }
-.tag-manager-container .edit-form { display: flex; flex-wrap: wrap; gap: 1rem; align-items: center; padding: 1rem; background-color: var(--color-bg-tertiary); border-top: 1px solid var(--color-border); border-radius: 0 0 var(--border-radius) var(--border-radius); }
+.tag-manager-container .edit-form {
+    display: flex; flex-wrap: wrap; gap: 1rem; align-items: center;
+    padding: 1rem; background-color: var(--color-bg-tertiary);
+    border-top: 1px solid var(--color-border); border-radius: 0 0 var(--border-radius) var(--border-radius);
+}
 .tag-manager-container .edit-form.hidden { display: none; }
 .tag-manager-container .edit-form input[type="text"] { padding: 0.5rem; font-size: 0.9rem; background-color: var(--color-bg-secondary); }
 .tag-manager-container .edit-form .cancel-btn { margin-left: auto; }
 .edit-action-group { display: flex; align-items: center; gap: 0.5rem; flex-grow: 1; }
 .edit-action-group input[type="text"] { flex-grow: 1; }
+.edit-action-group select {
+    padding: 0.5rem; font-size: 0.9rem; background-color: var(--color-bg-secondary);
+    color: var(--color-text-primary); border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+}
 #loading-message { text-align: center; color: var(--color-text-secondary); padding: 2rem; }
 
 
@@ -588,20 +456,11 @@ form.search-form button:hover {
 .saved-searches-container { max-width: 900px; margin: auto; text-align: left; }
 .search-list { list-style: none; padding: 0; margin-top: 1rem; }
 .search-item {
-    background-color: var(--color-bg-secondary);
-    border: 1px solid var(--color-border);
-    border-radius: var(--border-radius);
-    margin-bottom: 0.5rem;
-    padding: 0.8rem 1rem;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+    background-color: var(--color-bg-secondary); border: 1px solid var(--color-border);
+    border-radius: var(--border-radius); margin-bottom: 0.5rem; padding: 0.8rem 1rem;
+    display: flex; justify-content: space-between; align-items: center;
 }
-.search-item-query {
-    flex-grow: 1;
-    margin-right: 1rem;
-    color: var(--color-text-primary);
-}
+.search-item-query { flex-grow: 1; margin-right: 1rem; color: var(--color-text-primary); }
 .search-item-query:hover { text-decoration: underline; }
 .search-item-controls { display: flex; gap: 1rem; }
 .search-item-controls button {
@@ -610,54 +469,20 @@ form.search-form button:hover {
     opacity: 0.7; transition: opacity 0.2s;
 }
 .search-item-controls button:hover { opacity: 1; color: var(--color-accent); }
-.section-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding-bottom: 0.5rem;
-}
-.section-header button.clear-btn {
-    font-size: 0.8rem;
-    background-color: var(--color-danger);
-    color: white;
-    border-color: var(--color-danger);
-}
+.section-header { display: flex; justify-content: space-between; align-items: center; padding-bottom: 0.5rem; }
+.section-header button.clear-btn { font-size: 0.8rem; background-color: var(--color-danger); color: white; border-color: var(--color-danger); }
 
 
 /* --- 3.8 Help Page --- */
 .help-page { max-width: 800px; margin: auto; text-align: left; }
 .help-page li { background-color: var(--color-bg-secondary); border: 1px solid var(--color-border); margin-bottom: 0.5rem; padding: 1rem; border-radius: var(--border-radius); line-height: 1.5; }
-.help-page ul, .help-page ol {
-    list-style-type: none;
-    padding: 0;
-}
+.help-page ul, .help-page ol { list-style-type: none; padding: 0; }
 
 .toc {
-    background-color: var(--color-bg-secondary);
-    border: 1px solid var(--color-border);
-    border-radius: var(--border-radius);
-    padding: 1.5rem;
-    margin: 2rem 0;
+    background-color: var(--color-bg-secondary); border: 1px solid var(--color-border);
+    border-radius: var(--border-radius); padding: 1.5rem; margin: 2rem 0;
 }
-.toc strong {
-    display: block;
-    font-size: 1.2em;
-    margin-bottom: 1rem;
-    padding-bottom: 0.75rem;
-    border-bottom: 1px solid var(--color-border);
-}
-.toc ul {
-    list-style: none;
-    padding-left: 1rem;
-    margin: 0;
-}
-.toc li {
-    background: none;
-    border: none;
-    padding: 0.4rem 0;
-    margin: 0;
-    line-height: 1.4;
-}
-.toc li a:hover {
-    text-decoration: underline;
-}
+.toc strong { display: block; font-size: 1.2em; margin-bottom: 1rem; padding-bottom: 0.75rem; border-bottom: 1px solid var(--color-border); }
+.toc ul { list-style: none; padding-left: 1rem; margin: 0; }
+.toc li { background: none; border: none; padding: 0.4rem 0; margin: 0; line-height: 1.4; }
+.toc li a:hover { text-decoration: underline; }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -2,23 +2,8 @@
    STYLESHEET TABLE OF CONTENTS
    ==========================================================================
    1. Global Styles & Root Variables
-      - CSS Custom Properties (:root)
-      - Body & Typography (body, h1, a, code, etc.)
-
    2. Reusable Components
-      - 2.1 Autocomplete & Tag Pills
-      - 2.2 Generic Action Button
-      - 2.3 Toast Notifications
-
    3. Page-Specific Styles
-      - 3.1 Index Page
-      - 3.2 Upload Page
-      - 3.3 Gallery & Lightbox
-      - 3.4 Image Detail Page
-      - 3.5 Batch Actions Page
-      - 3.6 Tag Manager Page
-      - 3.7 Saved Searches Page
-      - 3.8 Help Page
    ========================================================================== */
 
 
@@ -288,6 +273,7 @@ form.search-form button {
 }
 form.search-form button:hover { background-color: var(--color-accent-hover); }
 
+/* This is the masonry layout for the gallery grid. */
 .gallery {
     column-width: var(--thumb-width);
     column-count: auto;
@@ -296,13 +282,14 @@ form.search-form button:hover { background-color: var(--color-accent-hover); }
 .thumb {
     width: 100%;
     margin-bottom: 1rem;
-    break-inside: avoid;
-    display: inline-block;
+    break-inside: avoid; /* Prevents thumbnails from breaking across columns. */
+    display: inline-block; /* Required for the column layout to work. */
     box-sizing: border-box;
     text-align: center;
     position: relative;
     border-radius: var(--border-radius);
-    /* Corrected: This is a standard fix for rendering/event bugs in column layouts */
+    /* This creates a new stacking context and is a standard fix for rendering/event
+       bugs that can occur with multi-column layouts in some browsers. */
     transform: translateZ(0);
 }
 .thumb img {
@@ -313,6 +300,7 @@ form.search-form button:hover { background-color: var(--color-accent-hover); }
     border-radius: var(--border-radius);
 }
 
+/* This is the dynamic tooltip that follows the mouse. */
 #tag-tooltip {
     position: fixed;
     background-color: rgba(18, 18, 18, 0.95);
@@ -327,12 +315,14 @@ form.search-form button:hover { background-color: var(--color-accent-hover); }
     opacity: 0;
     visibility: hidden;
     transition: opacity 0.2s ease-in-out, visibility 0.2s ease-in-out;
-    pointer-events: auto;
+    pointer-events: auto; /* Allow interaction with the tooltip and its content. */
 }
 #tag-tooltip.visible {
     opacity: 1;
     visibility: visible;
 }
+/* This class is used briefly by JS to calculate the tooltip's dimensions
+   without causing a visual flicker on the screen. */
 #tag-tooltip.visible-calculating {
     visibility: hidden !important;
     display: block !important;
@@ -397,28 +387,23 @@ form.search-form button:hover { background-color: var(--color-accent-hover); }
 /* --- 3.5 Batch Actions Page --- */
 #selection-controls, .page-actions { text-align: center; margin: 1rem 0; }
 .batch-gallery {
-    /* New: Apply masonry layout to batch actions page as well */
     column-width: var(--thumb-width);
     column-count: auto;
     column-gap: 1rem;
 }
 .batch-gallery .thumb {
-    /* New: Styling for items within the masonry layout */
     width: 100%;
     margin-bottom: 1rem;
     break-inside: avoid;
     display: inline-block;
-
-    /* Keep existing styles */
     border: 2px solid var(--color-border);
     user-select: none;
     cursor: pointer;
     overflow: visible;
-    transform: translateZ(0); /* New: Fix for column layout event bugs */
+    transform: translateZ(0);
 }
 .batch-gallery .thumb.selected { border-color: var(--color-accent); }
 .batch-gallery .thumb img { pointer-events: none; }
-/* New: Center the tag pills in batch mode */
 .batch-gallery .tag-pills-container {
     justify-content: center;
 }

--- a/templates/batch_actions.html
+++ b/templates/batch_actions.html
@@ -70,7 +70,7 @@
     document.addEventListener('DOMContentLoaded', () => {
 
         // --- 1. CONFIGURATION ---
-        const IMAGES_PER_PAGE = 42;
+        const IMAGES_PER_PAGE = 40;
 
         // --- 2. DOM ELEMENT REFERENCES ---
         const galleryGrid = document.getElementById('gallery-grid');

--- a/templates/batch_actions.html
+++ b/templates/batch_actions.html
@@ -87,10 +87,10 @@
         const urlParams = new URLSearchParams(window.location.search);
         const query = urlParams.get('q') || "";
         let currentPage = parseInt(urlParams.get('page')) || 1;
-        let currentImagesOnPage = []; // Stores image data for the current page to help with select/deselect all.
+        let currentImagesOnPage = []; // Caches image data for the current page.
         let isLoading = false;        // Prevents multiple simultaneous API calls.
         
-        // The Set of all selected image IDs, persisted in localStorage.
+        // The Set of all selected image IDs, persisted across page loads in localStorage.
         let selectedImageIds = new Set(JSON.parse(localStorage.getItem('batchSelectedImageIds') || "[]"));
 
         // --- 4. CORE FUNCTIONS (Rendering & Page State) ---
@@ -108,7 +108,6 @@
             const newUrl = `/batch_actions?q=${encodeURIComponent(query)}&page=${currentPage}`;
             window.history.pushState({ page: currentPage, query: query }, '', newUrl);
 
-            // Save the active search to recent history.
             if (query) {
                 addRecentSearch(query);
             }
@@ -130,13 +129,13 @@
         }
 
         /**
-         * New: Generates HTML for color-coded tag pills for display.
-         * @param {Array<Object>} tags - Array of tag objects [{name, category}].
+         * Generates the HTML for a set of color-coded tag pills.
+         * @param {Array<Object>} tags - An array of tag objects [{name, category}].
          * @returns {string} The HTML string for the tag pills.
          */
         function renderTagPills(tags) {
             if (!tags || tags.length === 0) {
-                return '&nbsp;'; // Return non-breaking space to maintain layout
+                return '&nbsp;'; // Return non-breaking space to maintain layout.
             }
             return tags.map(tag => {
                 const categoryClass = getTagCategoryClass(tag.category);
@@ -163,7 +162,6 @@
                 if (selectedImageIds.has(img.id)) {
                     thumb.classList.add('selected');
                 }
-                // New: Render tags using the pill container
                 const tagsHTML = `<div class="tag-pills-container">${renderTagPills(img.tags)}</div>`;
                 thumb.innerHTML = `<img src="/media/images/${img.filename}" alt="Image ${img.id}" loading="lazy"><div class="tags">${tagsHTML}</div>`;
                 galleryGrid.appendChild(thumb);
@@ -244,7 +242,7 @@
          */
         async function handleBatchRetag(imageIds, action) {
             const tags = batchTagsInput.value.trim();
-            if (!tags && action !== 'replace') {
+            if (!tags && action !== 'replace') { // 'replace' action can have empty tags to clear them.
                 showToast(`The '${action}' action requires at least one tag.`, 'info');
                 return;
             }
@@ -270,7 +268,7 @@
         }
         
         /**
-         * A simple UI helper to show or hide the tag input based on the selected action.
+         * A UI helper to show/hide the tag input based on the selected action.
          */
         function toggleTagInputVisibility() {
             const isDeleteAction = actionSelect.value === 'delete';
@@ -281,14 +279,13 @@
         // --- 6. INITIALIZATION & EVENT LISTENERS ---
         
         /**
-         * Handles all global keydown events for navigation shortcuts.
+         * Handles global keydown events for navigation shortcuts.
          * @param {KeyboardEvent} e - The keyboard event.
          */
         function handleKeydown(e) {
             // Ignore key presses if the user is typing in an input field.
             if (e.target.matches('input, textarea')) return;
 
-            // Page navigation
             const prevPageBtn = document.getElementById('prev-page');
             const nextPageBtn = document.getElementById('next-page');
 
@@ -374,7 +371,7 @@
 
             document.addEventListener('keydown', handleKeydown);
 
-            // --- Initial Setup Calls ---
+            // Initial Setup Calls
             setupTagAutocomplete(searchInput, suggestionsSearchBox, { showSavedSearches: true });
             setupTagAutocomplete(batchTagsInput, suggestionsBatchBox);
             toggleTagInputVisibility();

--- a/templates/batch_actions.html
+++ b/templates/batch_actions.html
@@ -55,7 +55,7 @@
                     type="text"
                     id="batchTagsInput"
                     name="tags"
-                    placeholder="e.g. cat, cute, sunset"
+                    placeholder="e.g. artist:name, character:name, general_tag"
                     autocomplete="off"
                 />
                 <div id="suggestions-batch" class="suggestions"></div>
@@ -130,6 +130,22 @@
         }
 
         /**
+         * New: Generates HTML for color-coded tag pills for display.
+         * @param {Array<Object>} tags - Array of tag objects [{name, category}].
+         * @returns {string} The HTML string for the tag pills.
+         */
+        function renderTagPills(tags) {
+            if (!tags || tags.length === 0) {
+                return '&nbsp;'; // Return non-breaking space to maintain layout
+            }
+            return tags.map(tag => {
+                const categoryClass = getTagCategoryClass(tag.category);
+                // These pills are for display only, not links.
+                return `<span class="tag-pill ${categoryClass}">${tag.name}</span>`;
+            }).join('');
+        }
+
+        /**
          * Renders the grid of image thumbnails into the gallery container.
          * @param {Array<Object>} images - An array of image objects from the API.
          */
@@ -147,7 +163,9 @@
                 if (selectedImageIds.has(img.id)) {
                     thumb.classList.add('selected');
                 }
-                thumb.innerHTML = `<img src="/media/images/${img.filename}" alt="Image ${img.id}" loading="lazy"><div class="tags">${img.tags.join(', ') || 'No tags'}</div>`;
+                // New: Render tags using the pill container
+                const tagsHTML = `<div class="tag-pills-container">${renderTagPills(img.tags)}</div>`;
+                thumb.innerHTML = `<img src="/media/images/${img.filename}" alt="Image ${img.id}" loading="lazy"><div class="tags">${tagsHTML}</div>`;
                 galleryGrid.appendChild(thumb);
             });
         }
@@ -226,7 +244,7 @@
          */
         async function handleBatchRetag(imageIds, action) {
             const tags = batchTagsInput.value.trim();
-            if (!tags) {
+            if (!tags && action !== 'replace') {
                 showToast(`The '${action}' action requires at least one tag.`, 'info');
                 return;
             }
@@ -314,6 +332,7 @@
             });
             
             document.getElementById('clearAllBtn').addEventListener('click', async () => {
+                if (selectedImageIds.size === 0) return;
                 const confirmed = await showConfirmation("Are you sure you want to clear all selections?");
                 if (confirmed) {
                     selectedImageIds.clear();

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -59,7 +59,7 @@
 document.addEventListener('DOMContentLoaded', () => {
 
     // --- 1. CONFIGURATION & CONSTANTS ---
-    const IMAGES_PER_PAGE = 20;
+    const IMAGES_PER_PAGE = 40;
     const DEFAULT_THUMB_SIZE = '250';
     const TOOLTIP_SHOW_DELAY = 100;
     const TOOLTIP_HIDE_DELAY = 50;

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -50,6 +50,8 @@
         </div>
     </div>
 
+    <div id="tag-tooltip" class="thumb-tooltip"></div>
+
 <script src="/static/js/notifications.js"></script>
 <script src="/static/js/autocomplete.js"></script>
 
@@ -59,6 +61,8 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- 1. CONFIGURATION & CONSTANTS ---
     const IMAGES_PER_PAGE = 20;
     const DEFAULT_THUMB_SIZE = '250';
+    const TOOLTIP_SHOW_DELAY = 250;
+    const TOOLTIP_HIDE_DELAY = 50;
 
     // --- 2. DOM ELEMENT REFERENCES ---
     const galleryGrid = document.getElementById('gallery-grid');
@@ -67,6 +71,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const thumbnailControls = document.getElementById('thumbnail-controls');
     const tagInput = document.getElementById('tagInput');
     const suggestionsBox = document.querySelector('.suggestions');
+    const tagTooltip = document.getElementById('tag-tooltip');
     
     // Lightbox elements
     const lightboxModal = document.getElementById('lightbox-modal');
@@ -86,6 +91,7 @@ document.addEventListener('DOMContentLoaded', () => {
     let currentImageIndex = -1; // Index of the currently viewed image in the lightbox
     let hasMorePages = true;
     let isLoading = false;        // Flag to prevent multiple simultaneous API calls
+    let showTooltipTimer, hideTooltipTimer; // Timers for managing tooltip state
 
     // --- 4. CORE FUNCTIONS ---
 
@@ -94,6 +100,7 @@ document.addEventListener('DOMContentLoaded', () => {
      * @param {number} [pageToLoad=1] - The page number to fetch and display.
      */
     async function loadPage(pageToLoad = 1) {
+        hideTooltip();
         if (isLoading) return;
         isLoading = true;
         
@@ -101,11 +108,9 @@ document.addEventListener('DOMContentLoaded', () => {
         currentImages = [];
         currentPage = pageToLoad;
         
-        // Update the browser's URL to reflect the current page and query.
         const newUrl = `/gallery?q=${encodeURIComponent(query)}&page=${currentPage}`;
         window.history.pushState({ page: currentPage, query: query }, '', newUrl);
 
-        // If a search query is active, save it to the recent searches history.
         if (query) {
             addRecentSearch(query);
         }
@@ -131,6 +136,23 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     /**
+     * Generates HTML for color-coded tag pills.
+     * @param {Array<Object>} tags - Array of tag objects [{name, category}].
+     * @returns {string} The HTML string for the tag pills.
+     */
+    function renderTagPills(tags) {
+        if (!tags || tags.length === 0) {
+            return '<span>No tags</span>';
+        }
+        return tags.map(tag => {
+            const categoryClass = getTagCategoryClass(tag.category);
+            const rawTagName = tag.category === 'general' ? tag.name : `${tag.category}:${tag.name}`;
+            const searchLink = `/gallery?q=${encodeURIComponent(rawTagName)}`;
+            return `<a href="${searchLink}" class="tag-pill ${categoryClass}">${tag.name}</a>`;
+        }).join('');
+    }
+
+    /**
      * Renders the grid of image thumbnails into the gallery container.
      * @param {Array<Object>} images - An array of image objects from the API.
      */
@@ -145,8 +167,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const thumb = document.createElement('div');
             thumb.className = 'thumb';
             thumb.dataset.index = index;
-            // The `loading="lazy"` attribute improves performance by only loading images as they scroll into view.
-            thumb.innerHTML = `<img src="/media/images/${img.filename}" alt="Image ${img.id}" loading="lazy"><div class="tags">${img.tags.join(', ') || 'No tags'}</div>`;
+            thumb.innerHTML = `<img src="/media/images/${img.filename}" alt="Image ${img.id}" loading="lazy">`;
             thumb.addEventListener('click', () => openLightbox(index));
             galleryGrid.appendChild(thumb);
         });
@@ -177,10 +198,10 @@ document.addEventListener('DOMContentLoaded', () => {
      * @param {number} index - The index of the image to show from the `currentImages` array.
      */
     function openLightbox(index) {
+        hideTooltip();
         currentImageIndex = index;
         showImageInLightbox(currentImageIndex);
         lightboxModal.style.display = 'flex';
-        // Prevent the main page from scrolling while the lightbox is open.
         document.body.style.overflow = 'hidden';
     }
 
@@ -204,17 +225,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const editButton = `<a href="/image/${image.id}" class="action-button">Edit Tags</a>`;
         const deleteButton = `<button id="delete-btn" class="action-button danger" data-image-id="${image.id}">Delete</button>`;
+        const tagsHTML = `<div class="tag-pills-container">${renderTagPills(image.tags)}</div>`;
 
         lightboxInfo.innerHTML = `
             <h4>Image ID: ${image.id}</h4>
-            <p>Tags: ${image.tags.join(', ') || 'No tags'}</p>
+            <div style="margin-bottom: 1rem;">${tagsHTML}</div>
             <div class="lightbox-actions">
                 ${editButton}
                 ${deleteButton}
             </div>
         `;
-
-        // Add event listener to the new delete button
         document.getElementById('delete-btn').addEventListener('click', handleDelete);
     }
 
@@ -224,19 +244,14 @@ document.addEventListener('DOMContentLoaded', () => {
     async function handleDelete(event) {
         const imageId = event.target.dataset.imageId;
         if (!imageId) return;
-
         const confirmed = await showConfirmation('Are you sure you want to permanently delete this image? This cannot be undone.');
         if (!confirmed) return;
-
         try {
-            const response = await fetch(`/api/image/${imageId}`, {
-                method: 'DELETE',
-            });
-
+            const response = await fetch(`/api/image/${imageId}`, { method: 'DELETE' });
             if (response.ok) {
                 showToast('Image deleted successfully.', 'success');
                 closeLightbox();
-                loadPage(currentPage); // Reload the gallery
+                loadPage(currentPage);
             } else {
                 const result = await response.json();
                 showToast(result.detail || 'Failed to delete image.', 'error');
@@ -253,13 +268,11 @@ document.addEventListener('DOMContentLoaded', () => {
      */
     async function navigateLightbox(direction) {
         const newIndex = currentImageIndex + direction;
-
         if (newIndex >= 0 && newIndex < currentImages.length) {
             currentImageIndex = newIndex;
             showImageInLightbox(currentImageIndex);
             return;
         }
-
         if (newIndex >= currentImages.length && hasMorePages) {
             await loadNextPageInLightbox();
         } else if (newIndex < 0 && currentPage > 1) {
@@ -275,7 +288,7 @@ document.addEventListener('DOMContentLoaded', () => {
         lightboxLoadingIndicator.style.display = 'block';
         await loadPage(currentPage + 1);
         lightboxLoadingIndicator.style.display = 'none';
-        openLightbox(0); // Open the first image of the newly loaded page.
+        openLightbox(0);
     }
 
     /**
@@ -286,10 +299,10 @@ document.addEventListener('DOMContentLoaded', () => {
         lightboxLoadingIndicator.style.display = 'block';
         await loadPage(currentPage - 1);
         lightboxLoadingIndicator.style.display = 'none';
-        openLightbox(currentImages.length - 1); // Open the last image of the newly loaded page.
+        openLightbox(currentImages.length - 1);
     }
 
-    // --- 6. MISC UI FUNCTIONS ---
+    // --- 6. MISC UI & TOOLTIP FUNCTIONS ---
 
     /**
      * Sets the CSS variable for thumbnail width and saves the preference.
@@ -302,6 +315,46 @@ document.addEventListener('DOMContentLoaded', () => {
         thumbnailControls.querySelector(`[data-size="${size}"]`)?.classList.add('active');
     }
 
+    /**
+     * Hides the tooltip and clears any pending timers.
+     */
+    function hideTooltip() {
+        clearTimeout(showTooltipTimer);
+        clearTimeout(hideTooltipTimer);
+        tagTooltip.classList.remove('visible');
+    }
+
+    /**
+     * Calculates the optimal position for the tooltip and displays it.
+     * @param {HTMLElement} thumb - The thumbnail element being hovered.
+     * @param {MouseEvent} event - The mouse event.
+     */
+    function showTooltip(thumb, event) {
+        const index = parseInt(thumb.dataset.index, 10);
+        const image = currentImages[index];
+        if (!image || !image.tags) return;
+
+        tagTooltip.innerHTML = renderTagPills(image.tags);
+        
+        tagTooltip.classList.add('visible-calculating');
+        const tooltipRect = tagTooltip.getBoundingClientRect();
+        tagTooltip.classList.remove('visible-calculating');
+
+        let left = event.clientX + 15;
+        let top = event.clientY + 15;
+
+        if (left + tooltipRect.width > window.innerWidth) {
+            left = event.clientX - tooltipRect.width - 15;
+        }
+        if (top + tooltipRect.height > window.innerHeight) {
+            top = event.clientY - tooltipRect.height - 15;
+        }
+
+        tagTooltip.style.left = `${left}px`;
+        tagTooltip.style.top = `${top}px`;
+        tagTooltip.classList.add('visible');
+    }
+
     // --- 7. EVENT HANDLERS ---
 
     /**
@@ -309,15 +362,12 @@ document.addEventListener('DOMContentLoaded', () => {
      * @param {KeyboardEvent} e - The keyboard event.
      */
     function handleKeydown(e) {
-        // Ignore key presses if the user is typing in an input field.
         if (e.target.matches('input, textarea')) return;
-
         if (lightboxModal.style.display === 'flex') {
             if (e.key === 'ArrowRight' || e.key.toLowerCase() === 'd') navigateLightbox(1);
             else if (e.key === 'ArrowLeft' || e.key.toLowerCase() === 'a') navigateLightbox(-1);
             else if (e.key === 'Escape') closeLightbox();
         } else {
-            // Gallery page navigation
             if ((e.key.toLowerCase() === 'd' || e.key === 'ArrowRight') && hasMorePages) {
                 loadPage(currentPage + 1);
             } else if ((e.key.toLowerCase() === 'a' || e.key === 'ArrowLeft') && currentPage > 1) {
@@ -330,35 +380,47 @@ document.addEventListener('DOMContentLoaded', () => {
      * Sets up the application by attaching event listeners and loading initial data.
      */
     function initialize() {
-        // Set thumbnail size from localStorage or use the default.
         const savedSize = localStorage.getItem('thumbSize') || DEFAULT_THUMB_SIZE;
         applyThumbSize(savedSize);
-        
-        // Only show the "Batch Actions" link if there's an active search.
-        if (query) {
-            batchEditLink.style.display = 'inline-block';
-        }
+        if (query) { batchEditLink.style.display = 'inline-block'; }
 
-        // Attach all event listeners.
         lightboxClose.addEventListener('click', closeLightbox);
         lightboxPrev.addEventListener('click', () => navigateLightbox(-1));
         lightboxNext.addEventListener('click', () => navigateLightbox(1));
         document.addEventListener('keydown', handleKeydown);
         thumbnailControls.addEventListener('click', (e) => {
-            if (e.target.dataset.size) {
-                applyThumbSize(e.target.dataset.size);
-            }
+            if (e.target.dataset.size) { applyThumbSize(e.target.dataset.size); }
         });
-        // Handle browser back/forward buttons.
         window.addEventListener('popstate', (e) => {
             const newPage = e.state?.page || 1;
             if (newPage !== currentPage) loadPage(newPage);
         });
 
-        // Set up the autocomplete for the main search bar.
-        setupTagAutocomplete(tagInput, suggestionsBox, { showSavedSearches: true });
+        // Corrected: Event delegation for smoother tooltip logic
+        galleryGrid.addEventListener('mouseover', e => {
+            const thumb = e.target.closest('.thumb');
+            if (thumb) {
+                clearTimeout(hideTooltipTimer);
+                clearTimeout(showTooltipTimer); // Clear any previous show timer
+                // Start a new timer to show the tooltip for the current thumb
+                showTooltipTimer = setTimeout(() => showTooltip(thumb, e), TOOLTIP_SHOW_DELAY);
+            }
+        });
+
+        galleryGrid.addEventListener('mouseout', e => {
+            const thumb = e.target.closest('.thumb');
+            if (thumb) {
+                clearTimeout(showTooltipTimer); // Cancel pending show if mouse leaves quickly
+                hideTooltipTimer = setTimeout(hideTooltip, TOOLTIP_HIDE_DELAY);
+            }
+        });
         
-        // Kick off the initial page load.
+        tagTooltip.addEventListener('mouseover', () => clearTimeout(hideTooltipTimer));
+        tagTooltip.addEventListener('mouseout', () => {
+            hideTooltipTimer = setTimeout(hideTooltip, TOOLTIP_HIDE_DELAY);
+        });
+
+        setupTagAutocomplete(tagInput, suggestionsBox, { showSavedSearches: true });
         loadPage(currentPage);
     }
 

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -63,7 +63,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const DEFAULT_THUMB_SIZE = '250';
     const TOOLTIP_SHOW_DELAY = 100;
     const TOOLTIP_HIDE_DELAY = 50;
-    const TOOLTIP_MODE_KEY = 'localBooru_tooltipModeEnabled'; // New: localStorage key
+    const TOOLTIP_MODE_KEY = 'localBooru_tooltipModeEnabled';
 
     // --- 2. DOM ELEMENT REFERENCES ---
     const galleryGrid = document.getElementById('gallery-grid');
@@ -88,12 +88,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const query = urlParams.get('q') || "";
     let currentPage = parseInt(urlParams.get('page')) || 1;
     let totalPages = 0;
-    let currentImages = [];       // Stores the image data for the current page
-    let currentImageIndex = -1; // Index of the currently viewed image in the lightbox
-    let hasMorePages = true;
-    let isLoading = false;        // Flag to prevent multiple simultaneous API calls
-    let showTooltipTimer, hideTooltipTimer; // Timers for managing tooltip state
-    // New: Read initial state from localStorage, defaulting to false.
+    let currentImages = [];       // Caches image data for the current gallery page.
+    let currentImageIndex = -1; // Index of the currently viewed image in the lightbox.
+    let hasMorePages = true;      // Flag to determine if a "Next" page exists.
+    let isLoading = false;        // Prevents multiple simultaneous API calls.
+    let showTooltipTimer, hideTooltipTimer; // Timers for managing tooltip hover intent.
     let isTooltipModeEnabled = localStorage.getItem(TOOLTIP_MODE_KEY) === 'true';
 
     // --- 4. CORE FUNCTIONS ---
@@ -139,8 +138,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     /**
-     * Generates HTML for color-coded tag pills.
-     * @param {Array<Object>} tags - Array of tag objects [{name, category}].
+     * Generates the HTML for a set of color-coded, clickable tag pills.
+     * @param {Array<Object>} tags - An array of tag objects [{name, category}].
      * @returns {string} The HTML string for the tag pills.
      */
     function renderTagPills(tags) {
@@ -308,7 +307,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- 6. MISC UI & TOOLTIP FUNCTIONS ---
 
     /**
-     * Sets the CSS variable for thumbnail width and saves the preference.
+     * Sets the CSS variable for thumbnail width and saves the preference to localStorage.
      * @param {string} size - The width in pixels (e.g., "250").
      */
     function applyThumbSize(size) {
@@ -319,7 +318,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     /**
-     * Hides the tooltip and clears any pending timers.
+     * Hides the dynamic tooltip and clears any pending timers.
      */
     function hideTooltip() {
         clearTimeout(showTooltipTimer);
@@ -330,7 +329,7 @@ document.addEventListener('DOMContentLoaded', () => {
     /**
      * Calculates the optimal position for the tooltip and displays it.
      * @param {HTMLElement} thumb - The thumbnail element being hovered.
-     * @param {MouseEvent} event - The mouse event.
+     * @param {MouseEvent} event - The mouse event that triggered the display.
      */
     function showTooltip(thumb, event) {
         const index = parseInt(thumb.dataset.index, 10);
@@ -339,6 +338,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         tagTooltip.innerHTML = renderTagPills(image.tags);
         
+        // Use a temporary class to calculate dimensions without a visual flicker.
         tagTooltip.classList.add('visible-calculating');
         const tooltipRect = tagTooltip.getBoundingClientRect();
         tagTooltip.classList.remove('visible-calculating');
@@ -346,6 +346,7 @@ document.addEventListener('DOMContentLoaded', () => {
         let left = event.clientX + 15;
         let top = event.clientY + 15;
 
+        // Smartly adjust position to prevent overflowing the viewport.
         if (left + tooltipRect.width > window.innerWidth) {
             left = event.clientX - tooltipRect.width - 15;
         }
@@ -361,7 +362,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- 7. EVENT HANDLERS ---
 
     /**
-     * Handles all global keydown events for navigation shortcuts.
+     * Handles all global keydown events for navigation and feature toggles.
      * @param {KeyboardEvent} e - The keyboard event.
      */
     function handleKeydown(e) {
@@ -369,18 +370,18 @@ document.addEventListener('DOMContentLoaded', () => {
         if (e.target.matches('input, textarea')) return;
 
         if (lightboxModal.style.display === 'flex') {
+            // Lightbox-specific shortcuts
             if (e.key === 'ArrowRight' || e.key.toLowerCase() === 'd') navigateLightbox(1);
             else if (e.key === 'ArrowLeft' || e.key.toLowerCase() === 'a') navigateLightbox(-1);
             else if (e.key === 'Escape') closeLightbox();
         } else {
-            // Gallery page navigation
+            // Gallery-specific shortcuts
             if ((e.key.toLowerCase() === 'd' || e.key === 'ArrowRight') && hasMorePages) {
                 loadPage(currentPage + 1);
             } else if ((e.key.toLowerCase() === 'a' || e.key === 'ArrowLeft') && currentPage > 1) {
                 loadPage(currentPage - 1);
             } else if (e.key.toLowerCase() === 't') {
                 isTooltipModeEnabled = !isTooltipModeEnabled;
-                // New: Save the new state to localStorage
                 localStorage.setItem(TOOLTIP_MODE_KEY, isTooltipModeEnabled);
                 const message = `Tooltip mode ${isTooltipModeEnabled ? 'enabled' : 'disabled'}.`;
                 showToast(message, 'info');
@@ -390,31 +391,13 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
     }
-    
+
     /**
-     * Sets up the application by attaching event listeners and loading initial data.
+     * Sets up the event listeners for the dynamic tooltip.
      */
-    function initialize() {
-        const savedSize = localStorage.getItem('thumbSize') || DEFAULT_THUMB_SIZE;
-        applyThumbSize(savedSize);
-        if (query) { batchEditLink.style.display = 'inline-block'; }
-
-        lightboxClose.addEventListener('click', closeLightbox);
-        lightboxPrev.addEventListener('click', () => navigateLightbox(-1));
-        lightboxNext.addEventListener('click', () => navigateLightbox(1));
-        document.addEventListener('keydown', handleKeydown);
-        thumbnailControls.addEventListener('click', (e) => {
-            if (e.target.dataset.size) { applyThumbSize(e.target.dataset.size); }
-        });
-        window.addEventListener('popstate', (e) => {
-            const newPage = e.state?.page || 1;
-            if (newPage !== currentPage) loadPage(newPage);
-        });
-
-        // Event delegation for dynamic tooltip, now conditional on tooltip mode
+    function setupTooltipEvents() {
         galleryGrid.addEventListener('mouseover', e => {
             if (!isTooltipModeEnabled) return;
-            
             const thumb = e.target.closest('.thumb');
             if (thumb) {
                 clearTimeout(hideTooltipTimer);
@@ -424,7 +407,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
         galleryGrid.addEventListener('mouseout', e => {
             if (!isTooltipModeEnabled) return;
-            
             const thumb = e.target.closest('.thumb');
             if (thumb) {
                 clearTimeout(showTooltipTimer);
@@ -441,8 +423,35 @@ document.addEventListener('DOMContentLoaded', () => {
             if (!isTooltipModeEnabled) return;
             hideTooltipTimer = setTimeout(hideTooltip, TOOLTIP_HIDE_DELAY);
         });
+    }
+    
+    /**
+     * Sets up all initial event listeners for the page.
+     */
+    function initialize() {
+        // Initial setup calls
+        const savedSize = localStorage.getItem('thumbSize') || DEFAULT_THUMB_SIZE;
+        applyThumbSize(savedSize);
+        if (query) { batchEditLink.style.display = 'inline-block'; }
 
+        // Attach event listeners
+        lightboxClose.addEventListener('click', closeLightbox);
+        lightboxPrev.addEventListener('click', () => navigateLightbox(-1));
+        lightboxNext.addEventListener('click', () => navigateLightbox(1));
+        document.addEventListener('keydown', handleKeydown);
+        thumbnailControls.addEventListener('click', (e) => {
+            if (e.target.dataset.size) { applyThumbSize(e.target.dataset.size); }
+        });
+        window.addEventListener('popstate', (e) => {
+            const newPage = e.state?.page || 1;
+            if (newPage !== currentPage) loadPage(newPage);
+        });
+
+        // Set up modular components
+        setupTooltipEvents();
         setupTagAutocomplete(tagInput, suggestionsBox, { showSavedSearches: true });
+        
+        // Kick off the initial page load.
         loadPage(currentPage);
     }
 

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -61,8 +61,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- 1. CONFIGURATION & CONSTANTS ---
     const IMAGES_PER_PAGE = 20;
     const DEFAULT_THUMB_SIZE = '250';
-    const TOOLTIP_SHOW_DELAY = 250;
+    const TOOLTIP_SHOW_DELAY = 100;
     const TOOLTIP_HIDE_DELAY = 50;
+    const TOOLTIP_MODE_KEY = 'localBooru_tooltipModeEnabled'; // New: localStorage key
 
     // --- 2. DOM ELEMENT REFERENCES ---
     const galleryGrid = document.getElementById('gallery-grid');
@@ -92,6 +93,8 @@ document.addEventListener('DOMContentLoaded', () => {
     let hasMorePages = true;
     let isLoading = false;        // Flag to prevent multiple simultaneous API calls
     let showTooltipTimer, hideTooltipTimer; // Timers for managing tooltip state
+    // New: Read initial state from localStorage, defaulting to false.
+    let isTooltipModeEnabled = localStorage.getItem(TOOLTIP_MODE_KEY) === 'true';
 
     // --- 4. CORE FUNCTIONS ---
 
@@ -362,16 +365,28 @@ document.addEventListener('DOMContentLoaded', () => {
      * @param {KeyboardEvent} e - The keyboard event.
      */
     function handleKeydown(e) {
+        // Ignore key presses if the user is typing in an input field.
         if (e.target.matches('input, textarea')) return;
+
         if (lightboxModal.style.display === 'flex') {
             if (e.key === 'ArrowRight' || e.key.toLowerCase() === 'd') navigateLightbox(1);
             else if (e.key === 'ArrowLeft' || e.key.toLowerCase() === 'a') navigateLightbox(-1);
             else if (e.key === 'Escape') closeLightbox();
         } else {
+            // Gallery page navigation
             if ((e.key.toLowerCase() === 'd' || e.key === 'ArrowRight') && hasMorePages) {
                 loadPage(currentPage + 1);
             } else if ((e.key.toLowerCase() === 'a' || e.key === 'ArrowLeft') && currentPage > 1) {
                 loadPage(currentPage - 1);
+            } else if (e.key.toLowerCase() === 't') {
+                isTooltipModeEnabled = !isTooltipModeEnabled;
+                // New: Save the new state to localStorage
+                localStorage.setItem(TOOLTIP_MODE_KEY, isTooltipModeEnabled);
+                const message = `Tooltip mode ${isTooltipModeEnabled ? 'enabled' : 'disabled'}.`;
+                showToast(message, 'info');
+                if (!isTooltipModeEnabled) {
+                    hideTooltip();
+                }
             }
         }
     }
@@ -396,27 +411,34 @@ document.addEventListener('DOMContentLoaded', () => {
             if (newPage !== currentPage) loadPage(newPage);
         });
 
-        // Corrected: Event delegation for smoother tooltip logic
+        // Event delegation for dynamic tooltip, now conditional on tooltip mode
         galleryGrid.addEventListener('mouseover', e => {
+            if (!isTooltipModeEnabled) return;
+            
             const thumb = e.target.closest('.thumb');
             if (thumb) {
                 clearTimeout(hideTooltipTimer);
-                clearTimeout(showTooltipTimer); // Clear any previous show timer
-                // Start a new timer to show the tooltip for the current thumb
                 showTooltipTimer = setTimeout(() => showTooltip(thumb, e), TOOLTIP_SHOW_DELAY);
             }
         });
 
         galleryGrid.addEventListener('mouseout', e => {
+            if (!isTooltipModeEnabled) return;
+            
             const thumb = e.target.closest('.thumb');
             if (thumb) {
-                clearTimeout(showTooltipTimer); // Cancel pending show if mouse leaves quickly
+                clearTimeout(showTooltipTimer);
                 hideTooltipTimer = setTimeout(hideTooltip, TOOLTIP_HIDE_DELAY);
             }
         });
         
-        tagTooltip.addEventListener('mouseover', () => clearTimeout(hideTooltipTimer));
+        tagTooltip.addEventListener('mouseover', () => {
+            if (!isTooltipModeEnabled) return;
+            clearTimeout(hideTooltipTimer);
+        });
+
         tagTooltip.addEventListener('mouseout', () => {
+            if (!isTooltipModeEnabled) return;
             hideTooltipTimer = setTimeout(hideTooltip, TOOLTIP_HIDE_DELAY);
         });
 

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -232,7 +232,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         lightboxInfo.innerHTML = `
             <h4>Image ID: ${image.id}</h4>
-            <div style="margin-bottom: 1rem;">${tagsHTML}</div>
+            <div>${tagsHTML}</div>
             <div class="lightbox-actions">
                 ${editButton}
                 ${deleteButton}

--- a/templates/help.html
+++ b/templates/help.html
@@ -15,9 +15,10 @@
         <ul>
             <li><a href="#uploading">1. Uploading Images</a></li>
             <li><a href="#gallery">2. The Gallery & Searching</a></li>
-            <li><a href="#advanced">3. Advanced Management</a></li>
-            <li><a href="#cli">4. Command-Line Utilities</a></li>
-            <li><a href="#shortcuts">5. Keyboard Shortcuts</a></li>
+            <li><a href="#categories">3. The Tag Category System</a></li>
+            <li><a href="#advanced">4. Advanced Management</a></li>
+            <li><a href="#cli">5. Command-Line Utilities</a></li>
+            <li><a href="#shortcuts">6. Keyboard Shortcuts</a></li>
         </ul>
     </div>
 
@@ -28,30 +29,33 @@
     </p>
     <ul>
         <li>
-            <strong>Selecting Files:</strong> Click the "Select image files" button to open a file dialog. You can select or drag & drop multiple image files at once. A small preview of each selected image will appear.
+            <strong>Selecting Files:</strong> You can select or drag & drop multiple image files and folders at once. A small preview of each selected image will appear.
         </li>
         <li>
-            <strong>Initial Tagging:</strong> Before you upload, you can add tags in the "Tags (comma-separated)" box. Every image in the batch will receive these initial tags. This is great for adding an artist's name or a common theme to a set of images.
+            <strong>Initial Tagging:</strong> Before you upload, you can add tags in the "Tags (comma-separated)" box. Every image in the batch will receive these initial tags. You can also add categorized tags here (see the section on the category system).
         </li>
         <li>
-            <strong>Uploading:</strong> Click the "Upload" button. The page will show a success message when the process is complete. The system automatically detects and skips any images you've already uploaded.
+            <strong>Uploading:</strong> Click the "Upload" button. The system automatically detects and skips any images you've already uploaded based on their content hash.
         </li>
     </ul>
 
     <!-- Section 2: The Gallery & Searching -->
     <h2 id="gallery">2. The Gallery & Searching</h2>
     <p>
-        The <strong><a href="/gallery">Gallery</a></strong> is the main page for viewing your collection. From here, you can browse, search, and inspect your images.
+        The <strong><a href="/gallery">Gallery</a></strong> is the main page for viewing your collection.
     </p>
     <ul>
         <li>
-            <strong>Thumbnail Size:</strong> Use the "Small," "Medium," and "Large" buttons at the top to change the size of the image thumbnails. Your preference is saved in your browser.
+            <strong>Masonry Layout:</strong> Images are displayed in a "masonry-style" grid that elegantly handles images of different heights.
         </li>
         <li>
-            <strong>Lightbox Viewer:</strong> Clicking on any thumbnail opens a full-size image viewer (a "lightbox"). You can navigate between images using the arrow buttons or your keyboard.
+            <strong>Tag Tooltips:</strong> To keep the view clean, tags are hidden by default. Press the <code>T</code> key on your keyboard to toggle a mode where hovering over an image will display its tags in a tooltip. Your preference for this mode is saved in your browser.
         </li>
         <li>
-            <strong>Editing or deleting from the Lightbox:</strong> Inside the lightbox, you will see the image's ID and its current tags. Click the "Edit Tags" button to go to a dedicated page to modify them, or "Delete" to remove it permanently from your collection.
+            <strong>Lightbox Viewer:</strong> Clicking on any thumbnail opens a full-size image viewer. You can navigate between images using the arrow buttons or your keyboard.
+        </li>
+        <li>
+            <strong>Editing or Deleting:</strong> Inside the lightbox, click the "Edit Tags" button to go to a dedicated page to modify them, or "Delete" to remove the image permanently.
         </li>
     </ul>
 
@@ -60,17 +64,17 @@
     
     <h4>Basic Search (AND Logic)</h4>
 	<p>
-		Tags are separated by commas (<code>,</code>) or the word <code>AND</code>. This finds images that have <strong>all</strong> of the specified tags.
+		Tags are separated by commas (<code>,</code>). This finds images that have <strong>all</strong> of the specified tags.
 	</p>
     <ul class="example-list">
         <li><code>cat, dog</code> - Finds images tagged with both <code>cat</code> AND <code>dog</code>.</li>
-		<li><code>cat AND dog</code> - Same as above.</li>
+		<li><code>artist:someartist, character:somechar</code> - Finds images with a specific artist AND a specific character.</li>
     </ul>
-
+    
     <h4>Advanced Operators</h4>
     <ul>
         <li>
-            <strong>OR Logic:</strong> Use parentheses with a vertical bar (<code>|</code>) or the word <code>OR</code>.
+            <strong>OR Logic:</strong> Use parentheses with a vertical bar (<code>|</code>).
             <ul class="example-list">
                 <li><code>(cat|dog)</code> - Finds images with either the <code>cat</code> OR <code>dog</code> tag.</li>
             </ul>
@@ -79,16 +83,18 @@
             <strong>Exclusion (NOT):</strong> To exclude images with a certain tag, prefix it with a hyphen (<code>-</code>).
             <ul class="example-list">
                 <li><code>-dog</code> - Finds all images that do NOT have the <code>dog</code> tag.</li>
+                <li><code>-character:reimu_hakurei</code> - Finds all images that are NOT of that character.</li>
             </ul>
         </li>
     </ul>
 
     <h4>Wildcard Search</h4>
     <p>
-        Use an asterisk (<code>*</code>) as a wildcard to match parts of a tag.
+        Use an asterisk (<code>*</code>) as a wildcard to match parts of a tag name.
     </p>
     <ul class="example-list">
         <li><code>cat*</code> - Finds tags starting with "cat," like <code>caterpillar</code> or <code>catgirl</code>.</li>
+        <li><code>artist:h*</code> - Finds artists starting with "h".</li>
     </ul>
 
     <h4>Special Queries</h4>
@@ -96,17 +102,31 @@
         <li><code>untagged</code> - A special keyword to find all images that have no tags assigned to them.</li>
     </ul>
 
-    <h3>Saved Searches</h3>
-    <p>To make searching even faster, the application automatically remembers your searches and allows you to "pin" your favorites.</p>
+    <!-- Section 3: Tag Categories -->
+    <h2 id="categories">3. The Tag Category System</h2>
+    <p>
+        To allow for more powerful organization, all tags belong to a category. This helps distinguish between different types of information, such as the artist of an image versus the subject matter. Tags are color-coded by their category for easy identification.
+    </p>
+    <h4>The Five Categories</h4>
     <ul>
-        <li><strong>Automatic Recent Searches:</strong> The last 10 unique searches you perform are automatically saved as "Recent Searches."</li>
-        <li><strong>Pinned Searches:</strong> You can permanently save a complex search by "pinning" it.</li>
-        <li><strong>Accessing Searches:</strong> Simply click on an empty search bar on the <strong>Homepage</strong>, <strong>Gallery</strong>, or <strong>Batch Actions</strong> page. A dropdown will appear showing your pinned and recent searches. Clicking one will instantly fill the search bar.</li>
-        <li><strong>Managing Searches:</strong> For full control, navigate to the <strong><a href="/saved_searches">Saved Searches</a></strong> page. Here you can view all searches, pin or unpin them, and delete any you no longer need.</li>
+        <li><code class="tag-pill tag-general">general</code>: For standard descriptive tags (e.g., <code>1girl</code>, <code>smile</code>, <code>outdoors</code>). This is the default category if none is specified.</li>
+        <li><code class="tag-pill tag-artist">artist</code>: For the creator of the artwork.</li>
+        <li><code class="tag-pill tag-character">character</code>: For named characters depicted in the image.</li>
+        <li><code class="tag-pill tag-copyright">copyright</code>: For the series, franchise, or game the content is from.</li>
+        <li><code class="tag-pill tag-metadata">metadata</code>: For technical details or user-specific information (e.g., <code>highres</code>, <code>comic</code>, <code>to_sort</code>).</li>
     </ul>
 
-    <!-- Section 3: Advanced Management -->
-    <h2 id="advanced">3. Advanced Management</h2>
+    <h4>How to Use Categories</h4>
+    <p>
+        You use categories by adding a prefix to your tag, followed by a colon (<code>:</code>). If you do not provide a prefix, the tag will automatically be assigned to the `general` category.
+    </p>
+    <ul class="example-list">
+        <li>Adding tags: <code>artist:someartist, character:somechar, 1girl, smile</code></li>
+        <li>Searching: <code>artist:someartist, -character:anotherchar</code></li>
+    </ul>
+
+    <!-- Section 4: Advanced Management -->
+    <h2 id="advanced">4. Advanced Management</h2>
     <p>For power users, the Batch Actions and Tag Manager pages provide tools for large-scale organization.</p>
     
     <h3>Batch Actions</h3>
@@ -122,19 +142,14 @@
     <h3>Tag Manager</h3>
     <p>The <strong><a href="/tag_manager">Tag Manager</a></strong> is for cleaning up the tags themselves, not the images.</p>
     <ul>
-        <li>
-            <strong>Rename:</strong> Changes a tag's name everywhere it's used (e.g., renaming <code>car</code> to <code>automobile</code>).
-        </li>
-        <li>
-            <strong>Merge:</strong> Combines two tags. All images with the "merge-from" tag will be given the "merge-to" tag, and the old tag will be deleted. This is useful for correcting duplicate tags (e.g., merging <code>cat</code> and <code>kitty</code> into just <code>cat</code>).
-        </li>
-        <li>
-            <strong>Force Delete:</strong> Deletes a tag from the system entirely, removing it from every image it was on. <strong>This can leave images untagged and cannot be undone.</strong>
-        </li>
+        <li><strong>Rename:</strong> Changes a tag's name everywhere it's used (e.g., renaming <code>car</code> to <code>automobile</code>).</li>
+        <li><strong>Change Category:</strong> Changes a tag's category. For example, you can move an incorrectly categorized tag from `general` to `artist`.</li>
+        <li><strong>Merge:</strong> Combines two tags into one. All images with the "merge-from" tag will be given the "merge-to" tag, and the old tag will be deleted. This is useful for correcting duplicate tags (e.g., merging <code>cat</code> and <code>kitty</code> into just <code>cat</code>).</li>
+        <li><strong>Force Delete:</strong> Deletes a tag from the system entirely, removing it from every image it was on. <strong>This can leave images untagged and cannot be undone.</strong></li>
     </ul>
     
-    <!-- Section 4: Command-Line Utilities -->
-    <h2 id="cli">4. Command-Line Utilities</h2>
+    <!-- Section 5: Command-Line Utilities -->
+    <h2 id="cli">5. Command-Line Utilities</h2>
     <p>
         Some maintenance tasks are performed using scripts from the command line, not the web interface. You must have terminal access to the server where the application is running to use these tools.
     </p>
@@ -164,8 +179,8 @@
         </ol>
     </div>
 
-    <!-- Section 5: Keyboard Shortcuts -->
-    <h2 id="shortcuts">5. Keyboard Shortcuts</h2>
+    <!-- Section 6: Keyboard Shortcuts -->
+    <h2 id="shortcuts">6. Keyboard Shortcuts</h2>
     <p>You can navigate the site quickly using your keyboard.</p>
     <ul>
         <li>
@@ -173,6 +188,7 @@
             <ul>
                 <li><code>A</code> or <code>ArrowLeft</code>: Go to the previous page.</li>
                 <li><code>D</code> or <code>ArrowRight</code>: Go to the next page.</li>
+                <li><code>T</code>: Toggle the tag tooltip display mode on and off.</li>
             </ul>
         </li>
         <li>

--- a/templates/tag_manager.html
+++ b/templates/tag_manager.html
@@ -76,8 +76,8 @@
 		}
 
 		/**
-		 * The central function that applies the current filter and sort settings
-		 * to the master tag list and calls the render function.
+		 * Applies the current filter and sort settings to the master tag list
+		 * and calls the render function.
 		 */
 		function applyFiltersAndRender() {
 			let tagsToRender = [...allTags];
@@ -91,7 +91,7 @@
 			}
 
 			if (currentSort === 'name') {
-				// New: Sort by category first, then name
+				// Sort by category first, then by name for logical grouping.
 				tagsToRender.sort((a, b) => a.category.localeCompare(b.category) || a.name.localeCompare(b.name));
 			} else { // currentSort === 'count'
 				tagsToRender.sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
@@ -134,7 +134,8 @@
 				li.id = `tag-item-${tag.id}`;
                 const categoryClass = getTagCategoryClass(tag.category);
                 const fullTagName = tag.category === 'general' ? tag.name : `${tag.category}:${tag.name}`;
-                
+                const categoryOptions = VALID_CATEGORIES.map(c => `<option value="${c}" ${c === tag.category ? 'selected' : ''}>${c}</option>`).join('');
+
 				li.innerHTML = `
 					<div class="tag-display">
 						<div>
@@ -154,9 +155,7 @@
 						</div>
                         <div class="edit-action-group">
 							<span>Change category to:</span>
-							<select id="category-select-${tag.id}">
-                                ${VALID_CATEGORIES.map(c => `<option value="${c}" ${c === tag.category ? 'selected' : ''}>${c}</option>`).join('')}
-                            </select>
+							<select id="category-select-${tag.id}">${categoryOptions}</select>
 							<button class="change-category-btn action-button" data-tag-id="${tag.id}" data-tag-name="${tag.name}">Save Category</button>
 						</div>
 						<span>or</span>
@@ -166,7 +165,7 @@
 								 <input type="text" id="merge-input-${tag.id}" placeholder="Type a tag name..." autocomplete="off" data-tag-id-to-keep="">
 								 <div id="suggestions-merge-${tag.id}" class="suggestions"></div>
 							</div>
-							<button class="merge-btn action-button" data-tag-id="${tag.id}" data-tag-name="${tag.name}" data-tag-category="${tag.category}">Merge</button>
+							<button class="merge-btn action-button" data-tag-id="${tag.id}" data-tag-name="${tag.name}">Merge</button>
 						</div>
 						<button class="cancel-btn action-button" data-tag-id="${tag.id}">Cancel</button>
 					</div>
@@ -188,7 +187,6 @@
 			if (!isNowHidden) {
 				const mergeInput = document.getElementById(`merge-input-${tagId}`);
 				const suggestionsBox = document.getElementById(`suggestions-merge-${tagId}`);
-				// This setup provides a custom `onSelect` callback to populate the hidden data attribute.
 				setupTagAutocomplete(mergeInput, suggestionsBox, { onSelect: (selectedTag) => {
                     const parsed = parseTag(selectedTag);
 					const tagObject = allTags.find(t => t.name === parsed.name && t.category === parsed.category);
@@ -224,20 +222,19 @@
 				});
 				const result = await response.json();
 				if (!response.ok) throw new Error(result.detail);
-
 				showToast(result.message, 'success');
-                await fetchAndInitialize(); // Full refresh
+                await fetchAndInitialize();
 			} catch (err) {
 				showToast(`Rename failed: ${err.message}`, 'error');
 			} finally {
-                toggleEditForm(tagId); // Always close the form after an attempt.
+                toggleEditForm(tagId);
             }
 		}
 
         /**
-         * New: Handles the API call to change a tag's category.
+         * Handles the API call to change a tag's category.
          * @param {string} tagId - The ID of the tag to change.
-         * @param {string} tagName - The name of the tag (for confirmation dialog).
+         * @param {string} tagName - The name of the tag for the confirmation dialog.
          */
         async function handleChangeCategory(tagId, tagName) {
             const newCategory = document.getElementById(`category-select-${tagId}`).value;
@@ -264,10 +261,9 @@
 		/**
 		 * Handles the API call to merge two tags.
 		 * @param {string} tagIdToDelete - The ID of the tag that will be merged and deleted.
-		 * @param {string} tagNameToDelete - The name of the tag to be deleted (for confirmation dialog).
-         * @param {string} tagCategory - The category of the tag to be deleted.
+		 * @param {string} tagNameToDelete - The name of the tag for the confirmation dialog.
 		 */
-		async function handleMerge(tagIdToDelete, tagNameToDelete, tagCategory) {
+		async function handleMerge(tagIdToDelete, tagNameToDelete) {
 			const mergeInput = document.getElementById(`merge-input-${tagIdToDelete}`);
 			const tagIdToKeep = mergeInput.dataset.tagIdToKeep;
 
@@ -288,7 +284,6 @@
 				const response = await fetch('/api/tags/merge', { method: 'POST', body: formData });
 				const result = await response.json();
 				if (!response.ok) throw new Error(result.detail);
-				
 				showToast(result.message, 'success');
                 await fetchAndInitialize();
 			} catch (err) {
@@ -301,7 +296,7 @@
 		/**
 		 * Handles the API call to permanently delete a tag from the database.
 		 * @param {string} tagId - The ID of the tag to delete.
-		 * @param {string} tagName - The name of the tag to delete (for confirmation dialog).
+		 * @param {string} tagName - The name of the tag for the confirmation dialog.
 		 */
 		async function handleForceDelete(tagId, tagName) {
 			const confirmed = await showConfirmation(`PERMANENTLY DELETE the tag "${tagName}"? This cannot be undone.`);
@@ -311,7 +306,6 @@
 				const response = await fetch(`/api/tags/force_delete/${tagId}`, { method: 'POST' });
 				const result = await response.json();
 				if (!response.ok) throw new Error(result.detail);
-
 				showToast(result.message, 'success');
                 await fetchAndInitialize();
 			} catch (err) {
@@ -347,16 +341,21 @@
 			tagListElem.addEventListener('click', (e) => {
 				const target = e.target;
 				const tagId = target.dataset.tagId;
+                const isActionButton = target.matches('.action-button');
+                
+                // Only prevent default for actual buttons, not links.
+				if (isActionButton) {
+                    e.preventDefault();
+                }
 
 				if (!tagId) return;
 
-                e.preventDefault(); // Prevent default link behavior for all actions
 				if (target.matches('.edit-btn') || target.matches('.cancel-btn')) {
 					toggleEditForm(tagId);
 				} else if (target.matches('.rename-btn')) {
 					handleRename(tagId);
 				} else if (target.matches('.merge-btn')) {
-					handleMerge(tagId, target.dataset.tagName, target.dataset.tagCategory);
+					handleMerge(tagId, target.dataset.tagName);
 				} else if (target.matches('.force-delete-btn')) {
 					handleForceDelete(tagId, target.dataset.tagName);
 				} else if (target.matches('.change-category-btn')) {

--- a/templates/tag_manager.html
+++ b/templates/tag_manager.html
@@ -91,7 +91,8 @@
 			}
 
 			if (currentSort === 'name') {
-				tagsToRender.sort((a, b) => a.name.localeCompare(b.name));
+				// New: Sort by category first, then name
+				tagsToRender.sort((a, b) => a.category.localeCompare(b.category) || a.name.localeCompare(b.name));
 			} else { // currentSort === 'count'
 				tagsToRender.sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
 			}
@@ -131,10 +132,14 @@
 				const li = document.createElement('li');
 				li.className = 'tag-item';
 				li.id = `tag-item-${tag.id}`;
+                const categoryClass = getTagCategoryClass(tag.category);
+                const fullTagName = tag.category === 'general' ? tag.name : `${tag.category}:${tag.name}`;
+                
 				li.innerHTML = `
 					<div class="tag-display">
 						<div>
-							<a href="/gallery?q=${encodeURIComponent(tag.name)}" class="tag-name-link">${tag.name}</a>
+                            <span class="tag-pill ${categoryClass}" style="cursor: default; margin-right: 0.5rem;">${tag.category}</span>
+							<a href="/gallery?q=${encodeURIComponent(fullTagName)}" class="tag-name-link">${tag.name}</a>
 							<span class="tag-count">(${tag.count})</span>
 						</div>
 						<div class="tag-controls">
@@ -147,6 +152,13 @@
 							<input type="text" value="${tag.name}" id="rename-input-${tag.id}" placeholder="New name...">
 							<button class="rename-btn action-button" data-tag-id="${tag.id}">Rename</button>
 						</div>
+                        <div class="edit-action-group">
+							<span>Change category to:</span>
+							<select id="category-select-${tag.id}">
+                                ${VALID_CATEGORIES.map(c => `<option value="${c}" ${c === tag.category ? 'selected' : ''}>${c}</option>`).join('')}
+                            </select>
+							<button class="change-category-btn action-button" data-tag-id="${tag.id}" data-tag-name="${tag.name}">Save Category</button>
+						</div>
 						<span>or</span>
 						<div class="edit-action-group merge-group">
 							<span>merge into:</span>
@@ -154,7 +166,7 @@
 								 <input type="text" id="merge-input-${tag.id}" placeholder="Type a tag name..." autocomplete="off" data-tag-id-to-keep="">
 								 <div id="suggestions-merge-${tag.id}" class="suggestions"></div>
 							</div>
-							<button class="merge-btn action-button" data-tag-id="${tag.id}" data-tag-name="${tag.name}">Merge</button>
+							<button class="merge-btn action-button" data-tag-id="${tag.id}" data-tag-name="${tag.name}" data-tag-category="${tag.category}">Merge</button>
 						</div>
 						<button class="cancel-btn action-button" data-tag-id="${tag.id}">Cancel</button>
 					</div>
@@ -178,7 +190,8 @@
 				const suggestionsBox = document.getElementById(`suggestions-merge-${tagId}`);
 				// This setup provides a custom `onSelect` callback to populate the hidden data attribute.
 				setupTagAutocomplete(mergeInput, suggestionsBox, { onSelect: (selectedTag) => {
-					const tagObject = allTags.find(t => t.name === selectedTag);
+                    const parsed = parseTag(selectedTag);
+					const tagObject = allTags.find(t => t.name === parsed.name && t.category === parsed.category);
 					if (tagObject) {
 						mergeInput.value = selectedTag;
 						mergeInput.dataset.tagIdToKeep = tagObject.id;
@@ -213,10 +226,7 @@
 				if (!response.ok) throw new Error(result.detail);
 
 				showToast(result.message, 'success');
-				const tagToUpdate = allTags.find(t => t.id == tagId);
-				if (tagToUpdate) tagToUpdate.name = newName;
-				
-				applyFiltersAndRender();
+                await fetchAndInitialize(); // Full refresh
 			} catch (err) {
 				showToast(`Rename failed: ${err.message}`, 'error');
 			} finally {
@@ -224,12 +234,40 @@
             }
 		}
 
+        /**
+         * New: Handles the API call to change a tag's category.
+         * @param {string} tagId - The ID of the tag to change.
+         * @param {string} tagName - The name of the tag (for confirmation dialog).
+         */
+        async function handleChangeCategory(tagId, tagName) {
+            const newCategory = document.getElementById(`category-select-${tagId}`).value;
+            const confirmed = await showConfirmation(`Change category of "${tagName}" to "${newCategory}"?`);
+            if (!confirmed) return;
+
+            try {
+                const response = await fetch(`/api/tags/change_category/${tagId}`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ new_category: newCategory })
+                });
+                const result = await response.json();
+                if (!response.ok) throw new Error(result.detail);
+                showToast(result.message, 'success');
+                await fetchAndInitialize();
+            } catch (err) {
+                showToast(`Category change failed: ${err.message}`, 'error');
+            } finally {
+                toggleEditForm(tagId);
+            }
+        }
+
 		/**
 		 * Handles the API call to merge two tags.
 		 * @param {string} tagIdToDelete - The ID of the tag that will be merged and deleted.
 		 * @param {string} tagNameToDelete - The name of the tag to be deleted (for confirmation dialog).
+         * @param {string} tagCategory - The category of the tag to be deleted.
 		 */
-		async function handleMerge(tagIdToDelete, tagNameToDelete) {
+		async function handleMerge(tagIdToDelete, tagNameToDelete, tagCategory) {
 			const mergeInput = document.getElementById(`merge-input-${tagIdToDelete}`);
 			const tagIdToKeep = mergeInput.dataset.tagIdToKeep;
 
@@ -252,19 +290,12 @@
 				if (!response.ok) throw new Error(result.detail);
 				
 				showToast(result.message, 'success');
-				// Update counts and remove the old tag from the local state for an instant UI update.
-				const tagToDelete = allTags.find(t => t.id == tagIdToDelete);
-				const tagToKeep = allTags.find(t => t.id == tagIdToKeep);
-				if (tagToDelete && tagToKeep) {
-					tagToKeep.count += tagToDelete.count;
-				}
-				allTags = allTags.filter(t => t.id != tagIdToDelete);
-
-				applyFiltersAndRender();
+                await fetchAndInitialize();
 			} catch (err) {
 				showToast(`Merge failed: ${err.message}`, 'error');
-				toggleEditForm(tagIdToDelete);
-			}
+			} finally {
+                toggleEditForm(tagIdToDelete);
+            }
 		}
 		
 		/**
@@ -282,9 +313,7 @@
 				if (!response.ok) throw new Error(result.detail);
 
 				showToast(result.message, 'success');
-				// Remove the tag from local state for an instant UI update.
-				allTags = allTags.filter(t => t.id != tagId);
-				applyFiltersAndRender();
+                await fetchAndInitialize();
 			} catch (err) {
 				showToast(`Deletion failed: ${err.message}`, 'error');
 			}
@@ -321,16 +350,18 @@
 
 				if (!tagId) return;
 
+                e.preventDefault(); // Prevent default link behavior for all actions
 				if (target.matches('.edit-btn') || target.matches('.cancel-btn')) {
-					e.preventDefault();
 					toggleEditForm(tagId);
 				} else if (target.matches('.rename-btn')) {
 					handleRename(tagId);
 				} else if (target.matches('.merge-btn')) {
-					handleMerge(tagId, target.dataset.tagName);
+					handleMerge(tagId, target.dataset.tagName, target.dataset.tagCategory);
 				} else if (target.matches('.force-delete-btn')) {
 					handleForceDelete(tagId, target.dataset.tagName);
-				}
+				} else if (target.matches('.change-category-btn')) {
+                    handleChangeCategory(tagId, target.dataset.tagName);
+                }
 			});
 		}
 		


### PR DESCRIPTION
This is a big one.

- Updates the backend to support and parse danbooru-style categories
- Updates the existing frontend so it can handle the new response from the API, and also for some eye candy (color-coded tags, for example)
- Updates the autocomplete suggestion system to support categories
- Updates tag_manager to support changing categories
- Added masonry-style thumbnail sorting for both the gallery and batch actions page

Closes #20 