### PR TITLE
fix: Prevent thumb selection when clicking tag pills

### DIFF
--- a/app/static/js/batch_actions.js
+++ b/app/static/js/batch_actions.js
@@ -205,6 +205,11 @@ document.addEventListener('DOMContentLoaded', () => {
 	function initializeEventListeners() {
 		// Setup listeners for all the batch action controls
 		galleryGrid.addEventListener('click', (e) => {
+			// If the user clicked on a tag pill, let the browser handle the navigation
+			// and don't treat it as a selection click.
+			if (e.target.closest('.tag-pill')) {
+				return;
+			}
 			const thumb = e.target.closest('.thumb');
 			if (thumb) {
 				const id = parseInt(thumb.dataset.imageId);


### PR DESCRIPTION
On the batch actions page, clicking a tag pill link would also toggle the selection of the parent thumbnail container. This was because the click event was bubbling up from the `<a>` tag to the `.thumb` div.

This fix modifies the `galleryGrid` click listener in `batch_actions.js`. It now checks if the click target is a `.tag-pill`. If it is, the handler returns early, allowing the default link behavior to occur without triggering the selection logic.

Closes #58 