### PR TITLE
fix: Create 'metadata:favorite' tag on first run

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -885,10 +885,6 @@ async def api_import_collection(file: UploadFile = File(...), db: Session = Depe
 
         db.commit()
 
-        # --- Ensure metadata:favorite tag exists -- -
-        get_or_create_tags(db, {"metadata:favorite"})
-        db.commit()
-
     return JSONResponse({
         "message": f"Import complete. Added {imported_count} new images and skipped {skipped_count} duplicates."
     })


### PR DESCRIPTION
Creates the 'metadata:favorite' tag as an orphan when the database is created for the first time. This ensures the tag is available for the favorite system from the beginning.

The redundant creation of this tag during collection import has been removed.

Closes #47 