### PR TITLE
fix: autocomplete dying with hyphens and QoL changes

### DIFF
--- a/app/static/js/autocomplete.js
+++ b/app/static/js/autocomplete.js
@@ -33,10 +33,29 @@ function setupTagAutocomplete(inputElement, suggestionsContainer, options = {}) 
      */
     function getAutocompleteContext(fullQuery) {
         const parts = fullQuery.split(new RegExp(',|\\sAND\\s|\\sOR\\s', 'i'));
-        const currentTerm = parts[parts.length - 1].trimStart();
-        const prefixLength = fullQuery.length - currentTerm.length;
-        const prefix = fullQuery.substring(0, prefixLength);
-        return { prefix, term: currentTerm.toLowerCase() };
+        const currentTermWithLeadingSpace = parts[parts.length - 1];
+
+        // The prefix is everything up to the last part
+        const prefixUpToLastPart = fullQuery.substring(0, fullQuery.length - currentTermWithLeadingSpace.length);
+
+        const trimmedPart = currentTermWithLeadingSpace.trimStart();
+
+        const spacePrefix = currentTermWithLeadingSpace.substring(0, currentTermWithLeadingSpace.length - trimmedPart.length);
+
+        let termForApi = trimmedPart;
+        let finalPrefix = prefixUpToLastPart + spacePrefix;
+
+        if (trimmedPart.startsWith('-')) {
+            // Don't treat a lone hyphen as a term to search for
+            if (trimmedPart.length > 1) {
+                termForApi = trimmedPart.substring(1);
+            } else {
+                termForApi = '';
+            }
+            finalPrefix += '-';
+        }
+
+        return { prefix: finalPrefix, term: termForApi.toLowerCase() };
     }
 
     /**

--- a/app/static/js/autocomplete.js
+++ b/app/static/js/autocomplete.js
@@ -32,7 +32,7 @@ function setupTagAutocomplete(inputElement, suggestionsContainer, options = {}) 
      * @returns {{prefix: string, term: string}}
      */
     function getAutocompleteContext(fullQuery) {
-        const parts = fullQuery.split(/,|\sAND\s|\sOR\s|\\||\(/i);
+        const parts = fullQuery.split(new RegExp(',|\\sAND\\s|\\sOR\\s', 'i'));
         const currentTerm = parts[parts.length - 1].trimStart();
         const prefixLength = fullQuery.length - currentTerm.length;
         const prefix = fullQuery.substring(0, prefixLength);

--- a/app/static/js/autocomplete.js
+++ b/app/static/js/autocomplete.js
@@ -32,7 +32,7 @@ function setupTagAutocomplete(inputElement, suggestionsContainer, options = {}) 
      * @returns {{prefix: string, term: string}}
      */
     function getAutocompleteContext(fullQuery) {
-        const parts = fullQuery.split(/,|\sAND\s|\sOR\s|\||\(|/i);
+        const parts = fullQuery.split(/,/i);
         const currentTerm = parts[parts.length - 1].trimStart();
         const prefixLength = fullQuery.length - currentTerm.length;
         const prefix = fullQuery.substring(0, prefixLength);

--- a/app/static/js/autocomplete.js
+++ b/app/static/js/autocomplete.js
@@ -32,7 +32,7 @@ function setupTagAutocomplete(inputElement, suggestionsContainer, options = {}) 
      * @returns {{prefix: string, term: string}}
      */
     function getAutocompleteContext(fullQuery) {
-        const parts = fullQuery.split(/,/i);
+        const parts = fullQuery.split(/,|\sAND\s|\sOR\s|\\||\(/i);
         const currentTerm = parts[parts.length - 1].trimStart();
         const prefixLength = fullQuery.length - currentTerm.length;
         const prefix = fullQuery.substring(0, prefixLength);

--- a/app/static/js/autocomplete.js
+++ b/app/static/js/autocomplete.js
@@ -32,7 +32,7 @@ function setupTagAutocomplete(inputElement, suggestionsContainer, options = {}) 
      * @returns {{prefix: string, term: string}}
      */
     function getAutocompleteContext(fullQuery) {
-        const parts = fullQuery.split(/,|\sAND\s|\sOR\s|\||\(|-/i);
+        const parts = fullQuery.split(/,|\sAND\s|\sOR\s|\||\(|/i);
         const currentTerm = parts[parts.length - 1].trimStart();
         const prefixLength = fullQuery.length - currentTerm.length;
         const prefix = fullQuery.substring(0, prefixLength);

--- a/app/templates/help.html
+++ b/app/templates/help.html
@@ -85,17 +85,20 @@
         </ul>
         
         <h5>Advanced Operators</h5>
+        <p>You can create more complex queries using the <code>OR</code> and <code>NOT</code> operators.</p>
         <ul>
             <li>
-                <strong>OR Logic:</strong> Use parentheses with a vertical bar (<code>|</code>).
+                <strong>OR Logic:</strong> Use the word <code>OR</code> between tags to find images that have <strong>either</strong> tag. This works at the top level of a query.
                 <ul class="example-list">
-                    <li><code>(cat|dog)</code> - Finds images with either the <code>cat</code> OR <code>dog</code> tag.</li>
+                    <li><code>cat OR dog</code> - Finds images with either the <code>cat</code> OR <code>dog</code> tag.</li>
+                    <li><code>character:reimu_hakurei OR character:marisa_kirisame</code> - Finds images of either character.</li>
+                    <li><code>cat, blue_eyes OR dog, brown_eyes</code> - Finds images that are (<code>cat</code> AND <code>blue_eyes</code>) OR (<code>dog</code> AND <code>brown_eyes</code>).</li>
                 </ul>
             </li>
             <li>
-                <strong>Exclusion (NOT):</strong> To exclude images with a certain tag, prefix it with a hyphen (<code>-</code>).
+                <strong>Exclusion (NOT):</strong> To exclude images with a certain tag, prefix the tag with a hyphen (<code>-</code>).
                 <ul class="example-list">
-                    <li><code>-dog</code> - Finds all images that do NOT have the <code>dog</code> tag.</li>
+                    <li><code>cat, -dog</code> - Finds images that have the <code>cat</code> tag but do NOT have the <code>dog</code> tag.</li>
                     <li><code>-character:reimu_hakurei</code> - Finds all images that are NOT of that character.</li>
                 </ul>
             </li>


### PR DESCRIPTION
Now parenthesis aren't required anymore while using AND or OR operators in search queries.

Closes #51 